### PR TITLE
Phase 3: AI pipeline generation and interactive wizard

### DIFF
--- a/cli/src/main/scala/com/dataweaver/cli/WeaverCLI.scala
+++ b/cli/src/main/scala/com/dataweaver/cli/WeaverCLI.scala
@@ -1,9 +1,7 @@
 package com.dataweaver.cli
 
 import com.dataweaver.cli.commands._
-import com.dataweaver.core.config.ProfileApplier
-import com.dataweaver.core.engine.EngineSelector
-import org.apache.spark.sql.SparkSession
+import com.dataweaver.cli.wizard.InteractiveWizard
 import scopt.OParser
 
 object WeaverCLI {
@@ -14,7 +12,10 @@ object WeaverCLI {
       env: Option[String] = None,
       inspectId: Option[String] = None,
       autoGenerate: Boolean = false,
-      showCoverage: Boolean = false
+      showCoverage: Boolean = false,
+      description: Option[String] = None,
+      interactive: Boolean = false,
+      projectName: Option[String] = None
   )
 
   def main(args: Array[String]): Unit = {
@@ -24,6 +25,26 @@ object WeaverCLI {
       OParser.sequence(
         programName("weaver"),
         head("Data Weaver", "0.2.0"),
+        cmd("init")
+          .action((_, c) => c.copy(command = "init"))
+          .text("Initialize a new project or generate pipeline interactively")
+          .children(
+            arg[String]("<project-name>")
+              .optional()
+              .action((x, c) => c.copy(projectName = Some(x)))
+              .text("Project name"),
+            opt[Unit]("interactive")
+              .action((_, c) => c.copy(interactive = true))
+              .text("Step-by-step pipeline wizard (no LLM required)")
+          ),
+        cmd("generate")
+          .action((_, c) => c.copy(command = "generate"))
+          .text("Generate pipeline YAML from natural language description")
+          .children(
+            arg[String]("<description>")
+              .action((x, c) => c.copy(description = Some(x)))
+              .text("Natural language description of the pipeline")
+          ),
         cmd("doctor")
           .action((_, c) => c.copy(command = "doctor"))
           .text("Full system diagnostic")
@@ -98,6 +119,11 @@ object WeaverCLI {
     OParser.parse(parser, args, Config()) match {
       case Some(config) =>
         config.command match {
+          case "init" =>
+            if (config.interactive) InteractiveWizard.run()
+            else InitCommand.run(config.projectName.getOrElse("my-project"))
+          case "generate" =>
+            GenerateCommand.run(config.description.get)
           case "doctor" =>
             val result = DoctorCommand.run(config.pipeline.get)
             if (!result.overallHealthy) sys.exit(1)

--- a/cli/src/main/scala/com/dataweaver/cli/ai/LLMClient.scala
+++ b/cli/src/main/scala/com/dataweaver/cli/ai/LLMClient.scala
@@ -1,0 +1,108 @@
+package com.dataweaver.cli.ai
+
+import org.apache.log4j.LogManager
+
+import java.net.URI
+import java.net.http.{HttpClient, HttpRequest, HttpResponse}
+import scala.util.{Failure, Success, Try}
+
+/** HTTP client for LLM APIs (Claude, OpenAI).
+  * Uses java.net.http — no external HTTP library dependencies.
+  */
+object LLMClient {
+  private val logger = LogManager.getLogger(getClass)
+  private val httpClient = HttpClient.newHttpClient()
+
+  /** Call an LLM API and return the generated text.
+    * @param prompt  The user prompt
+    * @param config  AI configuration (provider, apiKey, model)
+    * @return Right(generated text) or Left(error message)
+    */
+  def generate(prompt: String, config: WeaverConfig.AIConfig): Either[String, String] = {
+    if (config.apiKey.isEmpty) {
+      return Left(
+        s"No API key configured for '${config.provider}'. " +
+          s"Set it via ~/.weaver/config.yaml or environment variable " +
+          s"(ANTHROPIC_API_KEY for Claude, OPENAI_API_KEY for OpenAI)")
+    }
+
+    config.provider match {
+      case "claude" => callClaude(prompt, config)
+      case "openai" => callOpenAI(prompt, config)
+      case other    => Left(s"Unknown AI provider '$other'. Supported: claude, openai")
+    }
+  }
+
+  private def callClaude(prompt: String, config: WeaverConfig.AIConfig): Either[String, String] = {
+    val body = s"""{
+      "model": "${config.model}",
+      "max_tokens": 4096,
+      "messages": [{"role": "user", "content": ${escapeJson(prompt)}}]
+    }"""
+
+    val request = HttpRequest.newBuilder()
+      .uri(URI.create("https://api.anthropic.com/v1/messages"))
+      .header("Content-Type", "application/json")
+      .header("x-api-key", config.apiKey)
+      .header("anthropic-version", "2023-06-01")
+      .POST(HttpRequest.BodyPublishers.ofString(body))
+      .build()
+
+    executeRequest(request).flatMap(extractClaudeResponse)
+  }
+
+  private def callOpenAI(prompt: String, config: WeaverConfig.AIConfig): Either[String, String] = {
+    val body = s"""{
+      "model": "${config.model}",
+      "messages": [{"role": "user", "content": ${escapeJson(prompt)}}],
+      "max_tokens": 4096
+    }"""
+
+    val request = HttpRequest.newBuilder()
+      .uri(URI.create("https://api.openai.com/v1/chat/completions"))
+      .header("Content-Type", "application/json")
+      .header("Authorization", s"Bearer ${config.apiKey}")
+      .POST(HttpRequest.BodyPublishers.ofString(body))
+      .build()
+
+    executeRequest(request).flatMap(extractOpenAIResponse)
+  }
+
+  private def executeRequest(request: HttpRequest): Either[String, String] = {
+    Try(httpClient.send(request, HttpResponse.BodyHandlers.ofString())) match {
+      case Success(response) if response.statusCode() >= 200 && response.statusCode() < 300 =>
+        Right(response.body())
+      case Success(response) =>
+        Left(s"API error (${response.statusCode()}): ${response.body().take(500)}")
+      case Failure(e) =>
+        Left(s"Request failed: ${e.getMessage}")
+    }
+  }
+
+  /** Extract text content from Claude API response JSON. */
+  private def extractClaudeResponse(json: String): Either[String, String] = {
+    // Simple JSON extraction without a JSON library
+    val contentPattern = """"text"\s*:\s*"((?:[^"\\]|\\.)*)"""".r
+    contentPattern.findFirstMatchIn(json) match {
+      case Some(m) => Right(unescapeJson(m.group(1)))
+      case None    => Left(s"Cannot parse Claude response: ${json.take(500)}")
+    }
+  }
+
+  /** Extract text content from OpenAI API response JSON. */
+  private def extractOpenAIResponse(json: String): Either[String, String] = {
+    val contentPattern = """"content"\s*:\s*"((?:[^"\\]|\\.)*)"""".r
+    contentPattern.findFirstMatchIn(json) match {
+      case Some(m) => Right(unescapeJson(m.group(1)))
+      case None    => Left(s"Cannot parse OpenAI response: ${json.take(500)}")
+    }
+  }
+
+  private def escapeJson(s: String): String = {
+    "\"" + s.replace("\\", "\\\\").replace("\"", "\\\"").replace("\n", "\\n").replace("\r", "\\r").replace("\t", "\\t") + "\""
+  }
+
+  private def unescapeJson(s: String): String = {
+    s.replace("\\n", "\n").replace("\\r", "\r").replace("\\t", "\t").replace("\\\"", "\"").replace("\\\\", "\\")
+  }
+}

--- a/cli/src/main/scala/com/dataweaver/cli/ai/PromptBuilder.scala
+++ b/cli/src/main/scala/com/dataweaver/cli/ai/PromptBuilder.scala
@@ -1,0 +1,92 @@
+package com.dataweaver.cli.ai
+
+import scala.io.Source
+import scala.util.Try
+
+/** Builds schema-grounded prompts for LLM pipeline generation.
+  * The prompt includes the JSON Schema so the LLM generates structurally valid YAML.
+  */
+object PromptBuilder {
+
+  /** Build a prompt for generating a pipeline YAML from a natural language description.
+    * @param description User's natural language description of the pipeline
+    * @return Complete prompt with schema grounding
+    */
+  def buildGeneratePrompt(description: String): String = {
+    val schema = loadSchema()
+
+    s"""You are a data pipeline generator for Data Weaver, a declarative ETL framework.
+
+Generate a valid YAML pipeline based on this description:
+"$description"
+
+IMPORTANT RULES:
+1. Output ONLY the YAML content, no markdown fences, no explanation
+2. The YAML must conform to this JSON Schema:
+
+$schema
+
+3. Available source types: PostgreSQL, MySQL, File, Test
+4. Available sink types: BigQuery, DeltaLake, File, Test
+5. Available transform types: SQL, DataQuality
+6. Every sink MUST have a "source" field pointing to a transform id
+7. Use SQL transforms with standard SQL queries
+8. Add DataQuality checks where appropriate (row_count > 0, missing_count, duplicate_count)
+9. Use $${env.VAR} for any credentials or sensitive values
+10. Add inline tests to validate the pipeline output
+11. Set engine to "auto"
+
+CONNECTOR CONFIG REFERENCE:
+
+PostgreSQL source config: host, port, database, user, password, query
+MySQL source config: host, port, db, user, password, query, driver
+File source config: path, format (csv|json|parquet|orc), header (true|false)
+BigQuery sink config: projectId, datasetName, tableName, temporaryGcsBucket, saveMode
+DeltaLake sink config: path, saveMode (Overwrite|Append|merge), mergeKey
+File sink config: path, format (csv|json|parquet|orc), saveMode, coalesce, partitionBy
+
+Generate the YAML now:"""
+  }
+
+  /** Build a prompt for fixing a pipeline that failed validation.
+    * @param yaml      The invalid YAML
+    * @param errors    Validation error messages
+    * @return Prompt asking the LLM to fix the errors
+    */
+  def buildFixPrompt(yaml: String, errors: List[String]): String = {
+    s"""The following Data Weaver pipeline YAML has validation errors. Fix them.
+
+CURRENT YAML:
+$yaml
+
+ERRORS:
+${errors.mkString("\n")}
+
+RULES:
+1. Output ONLY the corrected YAML, no explanation
+2. Fix all listed errors
+3. Do not change parts that are already correct
+4. Every sink must have a "source" field
+5. All source references must exist as dataSource or transformation ids
+
+Generate the corrected YAML now:"""
+  }
+
+  /** Load the pipeline JSON Schema from resources. */
+  private def loadSchema(): String = {
+    Try {
+      val stream = getClass.getClassLoader.getResourceAsStream("schemas/pipeline.schema.json")
+      if (stream != null) {
+        val source = Source.fromInputStream(stream)
+        try source.mkString finally source.close()
+      } else {
+        // Fallback: read from file
+        val source = Source.fromFile("core/src/main/resources/schemas/pipeline.schema.json")
+        try source.mkString finally source.close()
+      }
+    }.getOrElse {
+      // Minimal inline schema as last resort
+      """{"type":"object","required":["name"],"properties":{"name":{"type":"string"},"dataSources":{"type":"array"},"transformations":{"type":"array"},"sinks":{"type":"array"}}}"""
+    }
+  }
+}

--- a/cli/src/main/scala/com/dataweaver/cli/ai/WeaverConfig.scala
+++ b/cli/src/main/scala/com/dataweaver/cli/ai/WeaverConfig.scala
@@ -1,0 +1,80 @@
+package com.dataweaver.cli.ai
+
+import scala.io.Source
+import scala.util.Try
+
+/** Loads ~/.weaver/config.yaml for AI settings.
+  *
+  * Expected format:
+  * {{{
+  * ai:
+  *   provider: claude          # claude | openai
+  *   apiKey: ${env.ANTHROPIC_API_KEY}
+  *   model: claude-sonnet-4-20250514
+  *   maxRetries: 3
+  * }}}
+  */
+object WeaverConfig {
+
+  case class AIConfig(
+      provider: String = "claude",
+      apiKey: String = "",
+      model: String = "claude-sonnet-4-20250514",
+      maxRetries: Int = 3
+  )
+
+  private val configPath = sys.props.getOrElse("user.home", ".") + "/.weaver/config.yaml"
+
+  /** Load AI configuration from ~/.weaver/config.yaml.
+    * Falls back to environment variables if config file doesn't exist.
+    */
+  def loadAIConfig(): AIConfig = {
+    val fromFile = loadFromFile(configPath)
+
+    // Resolve API key from env if it's a ${env.X} reference or empty
+    val apiKey = resolveApiKey(fromFile.apiKey, fromFile.provider)
+
+    fromFile.copy(apiKey = apiKey)
+  }
+
+  private def loadFromFile(path: String): AIConfig = {
+    Try {
+      val content = Source.fromFile(path).mkString
+      val lines = content.split('\n').map(_.trim)
+
+      var provider = "claude"
+      var apiKey = ""
+      var model = "claude-sonnet-4-20250514"
+      var maxRetries = 3
+
+      lines.foreach {
+        case l if l.startsWith("provider:") => provider = l.split(":", 2)(1).trim.split("#")(0).trim
+        case l if l.startsWith("apiKey:") => apiKey = l.split(":", 2)(1).trim
+        case l if l.startsWith("model:") => model = l.split(":", 2)(1).trim.split("#")(0).trim
+        case l if l.startsWith("maxRetries:") =>
+          maxRetries = Try(l.split(":", 2)(1).trim.toInt).getOrElse(3)
+        case _ =>
+      }
+
+      AIConfig(provider, apiKey, model, maxRetries)
+    }.getOrElse(AIConfig())
+  }
+
+  private def resolveApiKey(key: String, provider: String): String = {
+    val envPattern = """\$\{env\.([^}]+)\}""".r
+
+    envPattern.findFirstMatchIn(key) match {
+      case Some(m) =>
+        sys.env.getOrElse(m.group(1), "")
+      case None if key.nonEmpty =>
+        key
+      case _ =>
+        // Fallback to standard env vars
+        provider match {
+          case "claude" => sys.env.getOrElse("ANTHROPIC_API_KEY", "")
+          case "openai" => sys.env.getOrElse("OPENAI_API_KEY", "")
+          case _        => ""
+        }
+    }
+  }
+}

--- a/cli/src/main/scala/com/dataweaver/cli/commands/GenerateCommand.scala
+++ b/cli/src/main/scala/com/dataweaver/cli/commands/GenerateCommand.scala
@@ -1,0 +1,128 @@
+package com.dataweaver.cli.commands
+
+import com.dataweaver.cli.ai.{LLMClient, PromptBuilder, WeaverConfig}
+import com.dataweaver.core.config.{SchemaValidator, YAMLParser}
+import com.dataweaver.core.dag.DAGResolver
+
+import java.io.{File, PrintWriter}
+
+/** Generates pipeline YAML from natural language using an LLM.
+  * Implements a validation loop: generate → validate → retry (max N attempts).
+  */
+object GenerateCommand {
+
+  def run(description: String, outputPath: Option[String] = None): Unit = {
+    val config = WeaverConfig.loadAIConfig()
+
+    if (config.apiKey.isEmpty) {
+      System.err.println("ERROR: No AI API key configured.")
+      System.err.println()
+      System.err.println("Configure it in ~/.weaver/config.yaml:")
+      System.err.println("  ai:")
+      System.err.println("    provider: claude")
+      System.err.println("    apiKey: ${env.ANTHROPIC_API_KEY}")
+      System.err.println()
+      System.err.println("Or set the environment variable:")
+      System.err.println("  export ANTHROPIC_API_KEY=your-key-here")
+      return
+    }
+
+    println(s"Generating pipeline from: \"$description\"")
+    println(s"Using: ${config.provider} / ${config.model}")
+    println()
+
+    // Build initial prompt
+    val prompt = PromptBuilder.buildGeneratePrompt(description)
+
+    // Generation + validation loop
+    var yaml = ""
+    var attempt = 0
+    var valid = false
+
+    while (attempt < config.maxRetries && !valid) {
+      attempt += 1
+      println(s"  Attempt $attempt/${config.maxRetries}...")
+
+      val currentPrompt = if (attempt == 1) prompt
+        else PromptBuilder.buildFixPrompt(yaml, getErrors(yaml))
+
+      LLMClient.generate(currentPrompt, config) match {
+        case Right(generated) =>
+          yaml = cleanYaml(generated)
+          val errors = getErrors(yaml)
+          if (errors.isEmpty) {
+            valid = true
+            println(s"  ✓ Valid pipeline generated!")
+          } else {
+            println(s"  ✗ Validation failed (${errors.size} errors)")
+            errors.foreach(e => println(s"    - $e"))
+          }
+        case Left(error) =>
+          println(s"  ✗ LLM error: $error")
+          return
+      }
+    }
+
+    if (!valid) {
+      System.err.println()
+      System.err.println(s"Failed to generate valid pipeline after ${config.maxRetries} attempts.")
+      System.err.println("The best attempt was:")
+      System.err.println()
+      println(yaml)
+      return
+    }
+
+    // Output
+    val outFile = outputPath.getOrElse(inferOutputPath(description))
+    val writer = new PrintWriter(new File(outFile))
+    try writer.write(yaml)
+    finally writer.close()
+
+    println()
+    println(s"  Pipeline saved to: $outFile")
+    println()
+    println("  Next steps:")
+    println(s"    weaver validate $outFile")
+    println(s"    weaver plan $outFile")
+    println(s"    weaver apply $outFile")
+    println()
+  }
+
+  /** Validate YAML and return error list. */
+  private def getErrors(yaml: String): List[String] = {
+    YAMLParser.parseString(yaml) match {
+      case Left(parseError) => List(parseError)
+      case Right(config) =>
+        val schemaErrors = SchemaValidator.validate(config)
+        if (schemaErrors.nonEmpty) return schemaErrors
+        try {
+          DAGResolver.resolve(config)
+          List.empty
+        } catch {
+          case e: Exception => List(e.getMessage)
+        }
+    }
+  }
+
+  /** Clean LLM output — remove markdown fences and leading/trailing whitespace. */
+  private def cleanYaml(raw: String): String = {
+    var cleaned = raw.trim
+    // Remove markdown code fences
+    if (cleaned.startsWith("```yaml")) cleaned = cleaned.drop(7)
+    else if (cleaned.startsWith("```")) cleaned = cleaned.drop(3)
+    if (cleaned.endsWith("```")) cleaned = cleaned.dropRight(3)
+    cleaned.trim
+  }
+
+  /** Infer output filename from description. */
+  private def inferOutputPath(description: String): String = {
+    val name = description
+      .toLowerCase
+      .replaceAll("[^a-z0-9\\s]", "")
+      .trim
+      .split("\\s+")
+      .take(4)
+      .mkString("_")
+    s"${name}_pipeline.yaml"
+  }
+}

--- a/cli/src/main/scala/com/dataweaver/cli/commands/InitCommand.scala
+++ b/cli/src/main/scala/com/dataweaver/cli/commands/InitCommand.scala
@@ -1,0 +1,119 @@
+package com.dataweaver.cli.commands
+
+import java.io.{File, PrintWriter}
+import java.nio.file.{Files, Paths}
+
+/** Scaffolds a new Data Weaver project with example pipeline and config. */
+object InitCommand {
+
+  def run(projectName: String): Unit = {
+    val projectDir = Paths.get(projectName)
+
+    if (Files.exists(projectDir)) {
+      println(s"Project '$projectName' already exists.")
+      return
+    }
+
+    val pipelinesDir = projectDir.resolve("pipelines")
+    val configDir = projectDir.resolve("config")
+
+    Files.createDirectories(pipelinesDir)
+    Files.createDirectories(configDir)
+
+    // Example pipeline
+    writeFile(pipelinesDir.resolve("example_pipeline.yaml").toFile,
+      """name: ExamplePipeline
+        |tag: example
+        |engine: auto
+        |
+        |dataSources:
+        |  - id: source1
+        |    type: File
+        |    config:
+        |      path: data/input.csv
+        |      format: csv
+        |
+        |transformations:
+        |  - id: filtered
+        |    type: SQL
+        |    sources:
+        |      - source1
+        |    query: >
+        |      SELECT *
+        |      FROM source1
+        |      WHERE active = true
+        |
+        |  - id: quality_check
+        |    type: DataQuality
+        |    sources:
+        |      - filtered
+        |    checks:
+        |      - row_count > 0
+        |    onFail: warn
+        |
+        |sinks:
+        |  - id: output
+        |    type: File
+        |    source: quality_check
+        |    config:
+        |      path: data/output
+        |      format: parquet
+        |      saveMode: Overwrite
+        |
+        |profiles:
+        |  dev:
+        |    engine: local
+        |  prod:
+        |    engine: spark
+        |
+        |tests:
+        |  - name: "has data"
+        |    assert: output.row_count > 0
+        |""".stripMargin)
+
+    // Connections file
+    writeFile(configDir.resolve("connections.yaml").toFile,
+      """connections:
+        |  db-prod:
+        |    type: PostgreSQL
+        |    host: ${env.DB_HOST}
+        |    port: ${env.DB_PORT}
+        |    database: ${env.DB_NAME}
+        |    user: ${env.DB_USER}
+        |    password: ${env.DB_PASSWORD}
+        |""".stripMargin)
+
+    // .env example
+    writeFile(projectDir.resolve(".env.example").toFile,
+      """# Copy to .env and fill in values (gitignored)
+        |DB_HOST=localhost
+        |DB_PORT=5432
+        |DB_NAME=mydb
+        |DB_USER=myuser
+        |DB_PASSWORD=mypassword
+        |""".stripMargin)
+
+    // .gitignore
+    writeFile(projectDir.resolve(".gitignore").toFile,
+      """.env
+        |**/target/
+        |*.class
+        |.DS_Store
+        |""".stripMargin)
+
+    println(s"Project '$projectName' created successfully.")
+    println()
+    println("  Next steps:")
+    println(s"    cd $projectName")
+    println(s"    weaver validate pipelines/example_pipeline.yaml")
+    println(s"    weaver plan pipelines/example_pipeline.yaml")
+    println(s"    weaver apply pipelines/example_pipeline.yaml")
+    println()
+  }
+
+  private def writeFile(file: File, content: String): Unit = {
+    val writer = new PrintWriter(file)
+    try writer.write(content)
+    finally writer.close()
+  }
+}

--- a/cli/src/main/scala/com/dataweaver/cli/wizard/InteractiveWizard.scala
+++ b/cli/src/main/scala/com/dataweaver/cli/wizard/InteractiveWizard.scala
@@ -1,0 +1,196 @@
+package com.dataweaver.cli.wizard
+
+import java.io.{File, PrintWriter}
+import scala.io.StdIn
+
+/** Step-by-step interactive pipeline generator. No LLM required.
+  * Asks the user questions and generates valid YAML from the answers.
+  */
+object InteractiveWizard {
+
+  def run(): Unit = {
+    println()
+    println("  Data Weaver — Interactive Pipeline Wizard")
+    println("  " + "\u2500" * 45)
+    println()
+
+    // Pipeline name
+    val name = ask("Pipeline name", "MyPipeline")
+    val tag = ask("Tag (for filtering)", "daily")
+
+    // Data sources
+    println()
+    println("  Data Sources:")
+    val sourceType = choose("Source type", Seq("PostgreSQL", "MySQL", "File", "Test"))
+    val sourceId = ask("Source ID", "source1")
+
+    val sourceConfig = sourceType match {
+      case "PostgreSQL" | "MySQL" =>
+        val connection = ask("Connection name (from connections.yaml)", "db-prod")
+        val query = ask("SQL query", "SELECT * FROM my_table")
+        s"""    connection: $connection
+    query: >
+      $query
+    config:
+      readMode: ReadOnce"""
+
+      case "File" =>
+        val path = ask("File path", "data/input.csv")
+        val format = choose("Format", Seq("csv", "parquet", "json"))
+        s"""    config:
+      path: $path
+      format: $format"""
+
+      case "Test" =>
+        s"""    config:
+      readMode: ReadOnce"""
+
+      case _ => ""
+    }
+
+    // Transformations
+    println()
+    println("  Transformations:")
+    val addTransform = askYesNo("Add a SQL transformation?", default = true)
+    val transformYaml = if (addTransform) {
+      val transformId = ask("Transform ID", "transformed")
+      val query = ask("SQL query (use source ID as table name)", s"SELECT * FROM $sourceId WHERE active = true")
+      s"""transformations:
+  - id: $transformId
+    type: SQL
+    sources:
+      - $sourceId
+    query: >
+      $query"""
+    } else ""
+
+    val lastId = if (addTransform) ask("(confirm transform ID)", "transformed") else sourceId
+
+    // Quality checks
+    println()
+    val addQuality = askYesNo("Add data quality checks?", default = true)
+    val qualityYaml = if (addQuality) {
+      val qualityId = "quality_check"
+      s"""  - id: $qualityId
+    type: DataQuality
+    sources:
+      - $lastId
+    checks:
+      - row_count > 0
+      - missing_count(id) = 0
+    onFail: abort"""
+    } else ""
+
+    val sinkSource = if (addQuality) "quality_check" else lastId
+
+    // Sinks
+    println()
+    println("  Output:")
+    val sinkType = choose("Sink type", Seq("File", "DeltaLake", "BigQuery", "Test"))
+    val sinkId = ask("Sink ID", "output")
+
+    val sinkConfig = sinkType match {
+      case "File" =>
+        val path = ask("Output path", "output/result")
+        val format = choose("Format", Seq("parquet", "csv", "json"))
+        s"""    config:
+      path: $path
+      format: $format
+      saveMode: Overwrite"""
+
+      case "DeltaLake" =>
+        val path = ask("Delta Lake path", "s3://warehouse/table")
+        val saveMode = choose("Save mode", Seq("Overwrite", "Append", "merge"))
+        val mergeConfig = if (saveMode == "merge") s"\n      mergeKey: ${ask("Merge key column", "id")}" else ""
+        s"""    config:
+      path: $path
+      saveMode: $saveMode$mergeConfig"""
+
+      case "BigQuery" =>
+        val project = ask("GCP Project ID", "$${env.GCP_PROJECT}")
+        val dataset = ask("Dataset name", "my_dataset")
+        val table = ask("Table name", "my_table")
+        s"""    connection: bq-prod
+    config:
+      projectId: $project
+      datasetName: $dataset
+      tableName: $table
+      saveMode: Overwrite"""
+
+      case "Test" =>
+        s"""    config:
+      saveMode: Overwrite"""
+
+      case _ => ""
+    }
+
+    // Generate YAML
+    val transformSection = if (transformYaml.nonEmpty || qualityYaml.nonEmpty) {
+      val parts = Seq(transformYaml, qualityYaml).filter(_.nonEmpty)
+      if (transformYaml.nonEmpty) parts.mkString("\n") else s"transformations:\n${parts.mkString("\n")}"
+    } else ""
+
+    val yaml = s"""name: $name
+tag: $tag
+engine: auto
+dataSources:
+  - id: $sourceId
+    type: $sourceType
+$sourceConfig
+$transformSection
+sinks:
+  - id: $sinkId
+    type: $sinkType
+    source: $sinkSource
+$sinkConfig
+tests:
+  - name: "has data"
+    assert: $sinkId.row_count > 0
+"""
+
+    // Save
+    println()
+    println("  Generated Pipeline:")
+    println("  " + "\u2500" * 45)
+    println(yaml)
+
+    val outputFile = ask("Save to file", s"${name.toLowerCase.replaceAll("\\s+", "_")}.yaml")
+    val writer = new PrintWriter(new File(outputFile))
+    try writer.write(yaml)
+    finally writer.close()
+
+    println()
+    println(s"  ✓ Pipeline saved to: $outputFile")
+    println()
+    println("  Next steps:")
+    println(s"    weaver validate $outputFile")
+    println(s"    weaver plan $outputFile")
+    println(s"    weaver apply $outputFile")
+    println()
+  }
+
+  private def ask(prompt: String, default: String): String = {
+    print(s"  $prompt [$default]: ")
+    val input = StdIn.readLine()
+    if (input == null || input.trim.isEmpty) default else input.trim
+  }
+
+  private def choose(prompt: String, options: Seq[String]): String = {
+    println(s"  $prompt:")
+    options.zipWithIndex.foreach { case (opt, i) => println(s"    ${i + 1}) $opt") }
+    print(s"  Choice [1]: ")
+    val input = StdIn.readLine()
+    val idx = try {
+      if (input == null || input.trim.isEmpty) 0 else input.trim.toInt - 1
+    } catch { case _: Exception => 0 }
+    options(idx.max(0).min(options.size - 1))
+  }
+
+  private def askYesNo(prompt: String, default: Boolean): Boolean = {
+    val defaultStr = if (default) "Y/n" else "y/N"
+    print(s"  $prompt [$defaultStr]: ")
+    val input = StdIn.readLine()
+    if (input == null || input.trim.isEmpty) default
+    else input.trim.toLowerCase.startsWith("y")
+  }
+}

--- a/core/src/main/resources/schemas/pipeline.schema.json
+++ b/core/src/main/resources/schemas/pipeline.schema.json
@@ -1,0 +1,161 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Data Weaver Pipeline",
+  "description": "Declarative data pipeline definition for Data Weaver",
+  "type": "object",
+  "required": ["name"],
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "Unique pipeline name"
+    },
+    "tag": {
+      "type": "string",
+      "description": "Tag for filtering pipelines (e.g., daily, weekly)",
+      "default": ""
+    },
+    "engine": {
+      "type": "string",
+      "enum": ["auto", "spark", "local"],
+      "default": "auto",
+      "description": "Execution engine: auto (select based on data size), spark (distributed), local (DuckDB embedded)"
+    },
+    "dataSources": {
+      "type": "array",
+      "description": "Data sources to read from",
+      "items": {
+        "type": "object",
+        "required": ["id", "type"],
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Unique identifier, referenced by transformations"
+          },
+          "type": {
+            "type": "string",
+            "enum": ["PostgreSQL", "MySQL", "File", "Test"],
+            "description": "Source connector type"
+          },
+          "connection": {
+            "type": "string",
+            "description": "Named connection from connections.yaml"
+          },
+          "query": {
+            "type": "string",
+            "description": "SQL query or file path"
+          },
+          "config": {
+            "type": "object",
+            "description": "Connector-specific configuration",
+            "additionalProperties": { "type": "string" }
+          }
+        }
+      }
+    },
+    "transformations": {
+      "type": "array",
+      "description": "Data transformations applied in DAG order",
+      "items": {
+        "type": "object",
+        "required": ["id", "type"],
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Unique identifier, can be referenced by sinks or other transforms"
+          },
+          "type": {
+            "type": "string",
+            "enum": ["SQL", "DataQuality", "LLMTransform", "Chunking", "Embedding", "GraphExtraction"],
+            "description": "Transformation type"
+          },
+          "sources": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "IDs of data sources or transforms this reads from"
+          },
+          "query": {
+            "type": "string",
+            "description": "SQL query (for SQL type)"
+          },
+          "action": {
+            "type": "string",
+            "description": "Action name (for custom transforms)"
+          },
+          "checks": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Data quality checks (for DataQuality type): row_count > 0, missing_count(col) = 0, duplicate_count(col) = 0"
+          },
+          "onFail": {
+            "type": "string",
+            "enum": ["abort", "warn", "skip"],
+            "default": "abort",
+            "description": "Behavior when quality checks fail"
+          },
+          "config": {
+            "type": "object",
+            "additionalProperties": { "type": "string" }
+          }
+        }
+      }
+    },
+    "sinks": {
+      "type": "array",
+      "description": "Output destinations",
+      "items": {
+        "type": "object",
+        "required": ["id", "type"],
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Unique identifier"
+          },
+          "type": {
+            "type": "string",
+            "enum": ["BigQuery", "DeltaLake", "File", "Test"],
+            "description": "Sink connector type"
+          },
+          "source": {
+            "type": "string",
+            "description": "ID of the transform whose output this sink receives (REQUIRED when transforms exist)"
+          },
+          "connection": {
+            "type": "string",
+            "description": "Named connection from connections.yaml"
+          },
+          "config": {
+            "type": "object",
+            "description": "Connector-specific configuration (saveMode, path, etc.)",
+            "additionalProperties": { "type": "string" }
+          }
+        }
+      }
+    },
+    "profiles": {
+      "type": "object",
+      "description": "Environment-specific overrides (dev, prod)",
+      "additionalProperties": {
+        "type": "object",
+        "additionalProperties": { "type": "string" }
+      }
+    },
+    "tests": {
+      "type": "array",
+      "description": "Inline test assertions",
+      "items": {
+        "type": "object",
+        "required": ["name", "assert"],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Test name"
+          },
+          "assert": {
+            "type": "string",
+            "description": "Assertion expression: target.row_count > 0, sinks.X.missing_count(col) = 0"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds AI-powered pipeline generation from natural language and an interactive step-by-step wizard.

### AI Generation
- `LLMClient`: HTTP client for Claude and OpenAI APIs using `java.net.http` (zero external dependencies)
- `PromptBuilder`: schema-grounded prompts with full JSON Schema + connector reference
- `GenerateCommand`: `weaver generate "<description>"` with validation loop (generate → validate → retry, max 3 attempts)
- `WeaverConfig`: `~/.weaver/config.yaml` for AI provider, model, API key configuration

### Interactive Wizard
- `InteractiveWizard`: step-by-step pipeline creation without LLM (`weaver init --interactive`)
- Asks source type, connection, query, transforms, quality checks, sink type
- Generates valid YAML with inline tests

### Project Scaffolding
- `InitCommand`: `weaver init <project-name>` creates project structure with example pipeline, connections.yaml, .env.example, .gitignore

### Pipeline JSON Schema
- `core/src/main/resources/schemas/pipeline.schema.json` for IDE autocomplete and LLM prompt grounding

## New CLI commands
```bash
weaver init my-project              # Scaffold new project
weaver init --interactive            # Step-by-step wizard
weaver generate "description"        # AI pipeline generation
```

## Test plan

- [x] `sbt compile` — All modules compile
- [x] `sbt core/test` — 47 tests pass
- [ ] Manual: `weaver init test-project` creates project structure
- [ ] Manual: `weaver generate "read CSV, filter, write parquet"` with ANTHROPIC_API_KEY set