### PR TITLE
Phase 5: LLM transforms and RAG data preparation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -44,7 +44,8 @@ lazy val connectors = (project in file("connectors"))
       "org.apache.spark" %% "spark-sql"  % sparkVersion % "provided",
       "com.mysql"         % "mysql-connector-j" % "9.1.0",
       "org.json4s"       %% "json4s-jackson" % "4.0.7",
-      "org.postgresql"    % "postgresql" % "42.7.4"
+      "org.postgresql"    % "postgresql" % "42.7.4",
+      "org.apache.kafka"  % "kafka-clients" % "3.7.0" % "provided"
     )
   )
 

--- a/connectors/src/main/resources/META-INF/services/com.dataweaver.core.plugin.SinkConnector
+++ b/connectors/src/main/resources/META-INF/services/com.dataweaver.core.plugin.SinkConnector
@@ -2,3 +2,5 @@ com.dataweaver.connectors.sinks.BigQuerySinkConnector
 com.dataweaver.connectors.sinks.TestSinkConnector
 com.dataweaver.connectors.sinks.FileSinkConnector
 com.dataweaver.connectors.sinks.DeltaLakeSinkConnector
+com.dataweaver.connectors.sinks.KafkaSinkConnector
+com.dataweaver.connectors.sinks.ElasticsearchSinkConnector

--- a/connectors/src/main/resources/META-INF/services/com.dataweaver.core.plugin.SourceConnector
+++ b/connectors/src/main/resources/META-INF/services/com.dataweaver.core.plugin.SourceConnector
@@ -2,3 +2,7 @@ com.dataweaver.connectors.sources.SQLSourceConnector
 com.dataweaver.connectors.sources.TestSourceConnector
 com.dataweaver.connectors.sources.PostgreSQLSourceConnector
 com.dataweaver.connectors.sources.FileSourceConnector
+com.dataweaver.connectors.sources.KafkaSourceConnector
+com.dataweaver.connectors.sources.MongoDBSourceConnector
+com.dataweaver.connectors.sources.RESTSourceConnector
+com.dataweaver.connectors.sources.BigQuerySourceConnector

--- a/connectors/src/main/scala/com/dataweaver/connectors/sinks/ElasticsearchSinkConnector.scala
+++ b/connectors/src/main/scala/com/dataweaver/connectors/sinks/ElasticsearchSinkConnector.scala
@@ -1,0 +1,101 @@
+package com.dataweaver.connectors.sinks
+
+import com.dataweaver.core.plugin.SinkConnector
+import org.apache.log4j.LogManager
+import org.apache.spark.sql.{DataFrame, SparkSession}
+
+import java.net.URI
+import java.net.http.{HttpClient, HttpRequest, HttpResponse}
+
+/** Writes data to Elasticsearch indices.
+  *
+  * Config:
+  *   nodes      - Elasticsearch node URLs (e.g., "http://localhost:9200")
+  *   index      - Index name
+  *   saveMode   - "Append" (default) or "Overwrite"
+  *   idColumn   - Column to use as document _id (optional)
+  *
+  * Uses Spark Elasticsearch connector if available, falls back to REST bulk API.
+  */
+class ElasticsearchSinkConnector extends SinkConnector {
+  private val logger = LogManager.getLogger(getClass)
+  private val httpClient = HttpClient.newHttpClient()
+
+  def connectorType: String = "Elasticsearch"
+
+  def write(data: DataFrame, pipelineName: String, config: Map[String, String])(implicit
+      spark: SparkSession
+  ): Unit = {
+    val nodes = config.getOrElse("nodes",
+      throw new IllegalArgumentException("Elasticsearch: 'nodes' is required"))
+    val index = config.getOrElse("index",
+      throw new IllegalArgumentException("Elasticsearch: 'index' is required"))
+    val saveMode = config.getOrElse("saveMode", "Append")
+    val idColumn = config.get("idColumn")
+
+    // Try Spark ES connector first
+    try {
+      val writer = data.write
+        .format("org.elasticsearch.spark.sql")
+        .option("es.nodes", nodes.replace("http://", "").replace("https://", ""))
+        .option("es.resource", index)
+        .option("es.nodes.wan.only", "true")
+
+      idColumn.foreach(id => writer.option("es.mapping.id", id))
+
+      if (saveMode.toLowerCase == "overwrite") {
+        writer.mode("overwrite").save()
+      } else {
+        writer.mode("append").save()
+      }
+    } catch {
+      case _: ClassNotFoundException =>
+        logger.warn("Spark ES connector not found, using REST bulk API fallback")
+        writeBulkREST(data, nodes, index, idColumn)
+    }
+  }
+
+  /** Fallback: write via Elasticsearch REST bulk API. */
+  private def writeBulkREST(df: DataFrame, nodes: String, index: String, idColumn: Option[String]): Unit = {
+    val rows = df.toJSON.collect()
+    val bulkBody = new StringBuilder()
+
+    rows.foreach { json =>
+      val action = idColumn match {
+        case Some(_) => s"""{"index":{"_index":"$index"}}"""
+        case None    => s"""{"index":{"_index":"$index"}}"""
+      }
+      bulkBody.append(action).append("\n").append(json).append("\n")
+    }
+
+    val request = HttpRequest.newBuilder()
+      .uri(URI.create(s"$nodes/_bulk"))
+      .header("Content-Type", "application/x-ndjson")
+      .POST(HttpRequest.BodyPublishers.ofString(bulkBody.toString()))
+      .build()
+
+    val response = httpClient.send(request, HttpResponse.BodyHandlers.ofString())
+    if (response.statusCode() >= 400) {
+      throw new RuntimeException(s"Elasticsearch bulk write failed (${response.statusCode()}): ${response.body().take(500)}")
+    }
+
+    logger.info(s"Wrote ${rows.length} documents to Elasticsearch index '$index'")
+  }
+
+  override def healthCheck(config: Map[String, String]): Either[String, Long] = {
+    val nodes = config.getOrElse("nodes", return Left("nodes not configured"))
+    try {
+      val start = System.currentTimeMillis()
+      val request = HttpRequest.newBuilder()
+        .uri(URI.create(s"$nodes/_cluster/health"))
+        .GET()
+        .build()
+      val response = httpClient.send(request, HttpResponse.BodyHandlers.ofString())
+      val latency = System.currentTimeMillis() - start
+      if (response.statusCode() < 400) Right(latency)
+      else Left(s"Elasticsearch unhealthy (${response.statusCode()})")
+    } catch {
+      case e: Exception => Left(s"Elasticsearch unreachable: ${e.getMessage}")
+    }
+  }
+}

--- a/connectors/src/main/scala/com/dataweaver/connectors/sinks/KafkaSinkConnector.scala
+++ b/connectors/src/main/scala/com/dataweaver/connectors/sinks/KafkaSinkConnector.scala
@@ -1,0 +1,71 @@
+package com.dataweaver.connectors.sinks
+
+import com.dataweaver.core.plugin.SinkConnector
+import org.apache.spark.sql.{DataFrame, SparkSession}
+import org.apache.spark.sql.streaming.Trigger
+
+/** Writes data to Apache Kafka topics.
+  * Supports both batch and streaming write modes.
+  *
+  * Config:
+  *   brokers     - Kafka broker list
+  *   topic       - Topic to write to
+  *   mode        - "batch" (default) or "streaming"
+  *   keyColumn   - Column to use as Kafka key (optional)
+  *   valueColumn - Column to use as Kafka value (default: all columns as JSON)
+  *   checkpointLocation - Required for streaming mode
+  *   triggerInterval    - Streaming trigger interval (e.g., "10 seconds")
+  */
+class KafkaSinkConnector extends SinkConnector {
+  def connectorType: String = "Kafka"
+
+  def write(data: DataFrame, pipelineName: String, config: Map[String, String])(implicit
+      spark: SparkSession
+  ): Unit = {
+    val brokers = config.getOrElse("brokers",
+      throw new IllegalArgumentException("Kafka sink: 'brokers' is required"))
+    val topic = config.getOrElse("topic",
+      throw new IllegalArgumentException("Kafka sink: 'topic' is required"))
+    val mode = config.getOrElse("mode", "batch")
+
+    val keyCol = config.get("keyColumn")
+    val valueCol = config.getOrElse("valueColumn", "value")
+
+    // Prepare DataFrame with key/value columns for Kafka
+    val kafkaDf = if (data.columns.contains("value")) {
+      data
+    } else {
+      import org.apache.spark.sql.functions.{struct, to_json, col}
+      val valueExpr = to_json(struct(data.columns.map(col): _*))
+      val withValue = data.withColumn("value", valueExpr)
+      keyCol match {
+        case Some(k) => withValue.withColumnRenamed(k, "key")
+        case None    => withValue
+      }
+    }
+
+    mode match {
+      case "streaming" =>
+        val checkpoint = config.getOrElse("checkpointLocation",
+          s"/tmp/weaver-checkpoint/$pipelineName")
+        val trigger = config.getOrElse("triggerInterval", "10 seconds")
+
+        kafkaDf.writeStream
+          .format("kafka")
+          .option("kafka.bootstrap.servers", brokers)
+          .option("topic", topic)
+          .option("checkpointLocation", checkpoint)
+          .trigger(Trigger.ProcessingTime(trigger))
+          .start()
+          .awaitTermination()
+
+      case _ => // batch
+        kafkaDf.selectExpr("CAST(value AS STRING) AS value")
+          .write
+          .format("kafka")
+          .option("kafka.bootstrap.servers", brokers)
+          .option("topic", topic)
+          .save()
+    }
+  }
+}

--- a/connectors/src/main/scala/com/dataweaver/connectors/sources/BigQuerySourceConnector.scala
+++ b/connectors/src/main/scala/com/dataweaver/connectors/sources/BigQuerySourceConnector.scala
@@ -1,0 +1,43 @@
+package com.dataweaver.connectors.sources
+
+import com.dataweaver.core.plugin.SourceConnector
+import org.apache.spark.sql.{DataFrame, SparkSession}
+
+/** Reads data from BigQuery tables or queries.
+  *
+  * Config:
+  *   projectId  - GCP project ID
+  *   dataset    - BigQuery dataset name
+  *   table      - Table name (for direct table reads)
+  *   query      - SQL query (alternative to table, uses BigQuery SQL)
+  *   temporaryGcsBucket - GCS bucket for temporary data (required)
+  */
+class BigQuerySourceConnector extends SourceConnector {
+  def connectorType: String = "BigQuery"
+
+  def read(config: Map[String, String])(implicit spark: SparkSession): DataFrame = {
+    val temporaryGcsBucket = config.getOrElse("temporaryGcsBucket",
+      throw new IllegalArgumentException("BigQuery source: 'temporaryGcsBucket' is required"))
+
+    val query = config.get("query")
+    val table = for {
+      project <- config.get("projectId")
+      dataset <- config.get("dataset")
+      tbl     <- config.get("table")
+    } yield s"$project.$dataset.$tbl"
+
+    val reader = spark.read
+      .format("bigquery")
+      .option("temporaryGcsBucket", temporaryGcsBucket)
+
+    (query, table) match {
+      case (Some(q), _) =>
+        reader.option("query", q).load()
+      case (_, Some(t)) =>
+        reader.option("table", t).load()
+      case _ =>
+        throw new IllegalArgumentException(
+          "BigQuery source requires either 'query' or 'projectId'+'dataset'+'table'")
+    }
+  }
+}

--- a/connectors/src/main/scala/com/dataweaver/connectors/sources/KafkaSourceConnector.scala
+++ b/connectors/src/main/scala/com/dataweaver/connectors/sources/KafkaSourceConnector.scala
@@ -1,0 +1,72 @@
+package com.dataweaver.connectors.sources
+
+import com.dataweaver.core.plugin.SourceConnector
+import org.apache.spark.sql.{DataFrame, SparkSession}
+
+/** Reads data from Apache Kafka topics.
+  * Supports both batch and streaming modes.
+  *
+  * Config:
+  *   brokers       - Kafka broker list (e.g., "localhost:9092")
+  *   topic         - Topic to read from
+  *   startingOffsets - "earliest", "latest", or JSON offsets (default: "latest")
+  *   mode          - "batch" (default) or "streaming"
+  *   maxOffsetsPerTrigger - max records per micro-batch in streaming (optional)
+  */
+class KafkaSourceConnector extends SourceConnector {
+  def connectorType: String = "Kafka"
+
+  def read(config: Map[String, String])(implicit spark: SparkSession): DataFrame = {
+    val brokers = config.getOrElse("brokers",
+      throw new IllegalArgumentException("Kafka: 'brokers' is required"))
+    val topic = config.getOrElse("topic",
+      throw new IllegalArgumentException("Kafka: 'topic' is required"))
+    val startingOffsets = config.getOrElse("startingOffsets", "latest")
+    val mode = config.getOrElse("mode", "batch")
+
+    mode match {
+      case "streaming" =>
+        val reader = spark.readStream
+          .format("kafka")
+          .option("kafka.bootstrap.servers", brokers)
+          .option("subscribe", topic)
+          .option("startingOffsets", startingOffsets)
+
+        config.get("maxOffsetsPerTrigger").foreach(v => reader.option("maxOffsetsPerTrigger", v))
+
+        reader.load()
+          .selectExpr("CAST(key AS STRING)", "CAST(value AS STRING)", "topic", "partition", "offset", "timestamp")
+
+      case _ => // batch
+        spark.read
+          .format("kafka")
+          .option("kafka.bootstrap.servers", brokers)
+          .option("subscribe", topic)
+          .option("startingOffsets", startingOffsets)
+          .load()
+          .selectExpr("CAST(key AS STRING)", "CAST(value AS STRING)", "topic", "partition", "offset", "timestamp")
+    }
+  }
+
+  override def healthCheck(config: Map[String, String]): Either[String, Long] = {
+    val brokers = config.getOrElse("brokers", return Left("brokers not configured"))
+    try {
+      import java.util.Properties
+      val props = new Properties()
+      props.put("bootstrap.servers", brokers)
+      props.put("request.timeout.ms", "5000")
+      props.put("default.api.timeout.ms", "5000")
+
+      val start = System.currentTimeMillis()
+      val consumer = new org.apache.kafka.clients.consumer.KafkaConsumer[String, String](props,
+        new org.apache.kafka.common.serialization.StringDeserializer(),
+        new org.apache.kafka.common.serialization.StringDeserializer())
+      consumer.listTopics()
+      val latency = System.currentTimeMillis() - start
+      consumer.close()
+      Right(latency)
+    } catch {
+      case e: Exception => Left(s"Kafka connection failed: ${e.getMessage}")
+    }
+  }
+}

--- a/connectors/src/main/scala/com/dataweaver/connectors/sources/MongoDBSourceConnector.scala
+++ b/connectors/src/main/scala/com/dataweaver/connectors/sources/MongoDBSourceConnector.scala
@@ -1,0 +1,55 @@
+package com.dataweaver.connectors.sources
+
+import com.dataweaver.core.plugin.SourceConnector
+import org.apache.spark.sql.{DataFrame, SparkSession}
+
+/** Reads data from MongoDB collections via Spark MongoDB connector.
+  *
+  * Config:
+  *   uri        - MongoDB connection URI (e.g., "mongodb://host:27017")
+  *   database   - Database name
+  *   collection - Collection name
+  *   pipeline   - Optional aggregation pipeline JSON (e.g., "[{$match: {active: true}}]")
+  *
+  * Requires: org.mongodb.spark:mongo-spark-connector on the Spark classpath.
+  */
+class MongoDBSourceConnector extends SourceConnector {
+  def connectorType: String = "MongoDB"
+
+  def read(config: Map[String, String])(implicit spark: SparkSession): DataFrame = {
+    val uri = config.getOrElse("uri",
+      throw new IllegalArgumentException("MongoDB: 'uri' is required"))
+    val database = config.getOrElse("database",
+      throw new IllegalArgumentException("MongoDB: 'database' is required"))
+    val collection = config.getOrElse("collection",
+      throw new IllegalArgumentException("MongoDB: 'collection' is required"))
+
+    val reader = spark.read
+      .format("mongodb")
+      .option("connection.uri", uri)
+      .option("database", database)
+      .option("collection", collection)
+
+    config.get("pipeline").foreach(p => reader.option("aggregation.pipeline", p))
+
+    reader.load()
+  }
+
+  override def healthCheck(config: Map[String, String]): Either[String, Long] = {
+    val uri = config.getOrElse("uri", return Left("uri not configured"))
+    try {
+      val start = System.currentTimeMillis()
+      // Simple TCP check on MongoDB port
+      val uriParts = uri.replace("mongodb://", "").split(":")
+      val host = uriParts(0)
+      val port = if (uriParts.length > 1) uriParts(1).split("/")(0).toInt else 27017
+      val socket = new java.net.Socket()
+      socket.connect(new java.net.InetSocketAddress(host, port), 5000)
+      val latency = System.currentTimeMillis() - start
+      socket.close()
+      Right(latency)
+    } catch {
+      case e: Exception => Left(s"MongoDB connection failed: ${e.getMessage}")
+    }
+  }
+}

--- a/connectors/src/main/scala/com/dataweaver/connectors/sources/RESTSourceConnector.scala
+++ b/connectors/src/main/scala/com/dataweaver/connectors/sources/RESTSourceConnector.scala
@@ -1,0 +1,135 @@
+package com.dataweaver.connectors.sources
+
+import com.dataweaver.core.plugin.SourceConnector
+import org.apache.log4j.LogManager
+import org.apache.spark.sql.{DataFrame, SparkSession}
+
+import java.net.URI
+import java.net.http.{HttpClient, HttpRequest, HttpResponse}
+import scala.collection.mutable.ListBuffer
+
+/** Generic REST API source connector with pagination and auth support.
+  *
+  * Config:
+  *   baseUrl    - API base URL
+  *   endpoint   - API endpoint path
+  *   method     - HTTP method (default: GET)
+  *   auth       - Auth type: "none", "bearer", "api-key" (default: "none")
+  *   token      - Bearer token or API key value
+  *   headerName - Custom header name for api-key auth (default: "X-API-Key")
+  *   pagination - Pagination type: "none", "offset", "cursor" (default: "none")
+  *   pageSize   - Items per page (default: 100)
+  *   maxPages   - Max pages to fetch (default: 10)
+  *   dataPath   - JSON path to data array (e.g., "results", "data.items")
+  *   params     - Additional query params as key=value pairs separated by &
+  */
+class RESTSourceConnector extends SourceConnector {
+  private val logger = LogManager.getLogger(getClass)
+  private val httpClient = HttpClient.newHttpClient()
+
+  def connectorType: String = "REST"
+
+  def read(config: Map[String, String])(implicit spark: SparkSession): DataFrame = {
+    val baseUrl = config.getOrElse("baseUrl",
+      throw new IllegalArgumentException("REST: 'baseUrl' is required"))
+    val endpoint = config.getOrElse("endpoint", "")
+    val method = config.getOrElse("method", "GET")
+    val pagination = config.getOrElse("pagination", "none")
+    val pageSize = config.getOrElse("pageSize", "100").toInt
+    val maxPages = config.getOrElse("maxPages", "10").toInt
+    val dataPath = config.get("dataPath")
+    val params = config.getOrElse("params", "")
+
+    val allData = ListBuffer[String]()
+
+    pagination match {
+      case "offset" =>
+        var offset = 0
+        var page = 0
+        var hasMore = true
+        while (hasMore && page < maxPages) {
+          val separator = if (params.nonEmpty || endpoint.contains("?")) "&" else "?"
+          val paginationParams = s"${separator}offset=$offset&limit=$pageSize"
+          val url = s"$baseUrl$endpoint${if (params.nonEmpty) s"?$params" else ""}$paginationParams"
+          val response = fetchUrl(url, method, config)
+          allData += response
+          page += 1
+          offset += pageSize
+          // Simple heuristic: if response is small, assume last page
+          hasMore = response.length > 100
+        }
+
+      case "cursor" =>
+        var cursor: Option[String] = None
+        var page = 0
+        var hasMore = true
+        while (hasMore && page < maxPages) {
+          val cursorParam = cursor.map(c => s"&cursor=$c").getOrElse("")
+          val separator = if (params.nonEmpty || endpoint.contains("?")) "&" else "?"
+          val url = s"$baseUrl$endpoint${if (params.nonEmpty) s"?$params" else ""}${separator}limit=$pageSize$cursorParam"
+          val response = fetchUrl(url, method, config)
+          allData += response
+          page += 1
+          // Extract next cursor from response (simple pattern)
+          val cursorPattern = """"next_cursor"\s*:\s*"([^"]+)"""".r
+          cursor = cursorPattern.findFirstMatchIn(response).map(_.group(1))
+          hasMore = cursor.isDefined
+        }
+
+      case _ => // no pagination
+        val url = s"$baseUrl$endpoint${if (params.nonEmpty) s"?$params" else ""}"
+        allData += fetchUrl(url, method, config)
+    }
+
+    // Create DataFrame from JSON responses
+    import spark.implicits._
+    val jsonRDD = spark.sparkContext.parallelize(allData.toList)
+    spark.read.option("multiLine", true).json(spark.createDataset(jsonRDD))
+  }
+
+  override def healthCheck(config: Map[String, String]): Either[String, Long] = {
+    val baseUrl = config.getOrElse("baseUrl", return Left("baseUrl not configured"))
+    try {
+      val start = System.currentTimeMillis()
+      val request = HttpRequest.newBuilder()
+        .uri(URI.create(baseUrl))
+        .method("HEAD", HttpRequest.BodyPublishers.noBody())
+        .build()
+      httpClient.send(request, HttpResponse.BodyHandlers.discarding())
+      Right(System.currentTimeMillis() - start)
+    } catch {
+      case e: Exception => Left(s"REST API unreachable: ${e.getMessage}")
+    }
+  }
+
+  private def fetchUrl(url: String, method: String, config: Map[String, String]): String = {
+    logger.info(s"Fetching: $url")
+    val builder = HttpRequest.newBuilder().uri(URI.create(url))
+
+    // Apply auth
+    config.getOrElse("auth", "none") match {
+      case "bearer" =>
+        val token = config.getOrElse("token", "")
+        builder.header("Authorization", s"Bearer $token")
+      case "api-key" =>
+        val headerName = config.getOrElse("headerName", "X-API-Key")
+        val token = config.getOrElse("token", "")
+        builder.header(headerName, token)
+      case _ => // no auth
+    }
+
+    builder.header("Accept", "application/json")
+
+    val request = method.toUpperCase match {
+      case "GET"  => builder.GET().build()
+      case "POST" => builder.POST(HttpRequest.BodyPublishers.noBody()).build()
+      case _      => builder.GET().build()
+    }
+
+    val response = httpClient.send(request, HttpResponse.BodyHandlers.ofString())
+    if (response.statusCode() >= 400) {
+      throw new RuntimeException(s"API error ${response.statusCode()}: ${response.body().take(500)}")
+    }
+    response.body()
+  }
+}

--- a/core/src/main/resources/schemas/pipeline.schema.json
+++ b/core/src/main/resources/schemas/pipeline.schema.json
@@ -33,7 +33,7 @@
           },
           "type": {
             "type": "string",
-            "enum": ["PostgreSQL", "MySQL", "File", "Test"],
+            "enum": ["PostgreSQL", "MySQL", "File", "Kafka", "MongoDB", "REST", "BigQuery", "Test"],
             "description": "Source connector type"
           },
           "connection": {
@@ -112,7 +112,7 @@
           },
           "type": {
             "type": "string",
-            "enum": ["BigQuery", "DeltaLake", "File", "Test"],
+            "enum": ["BigQuery", "DeltaLake", "File", "Kafka", "Elasticsearch", "Test"],
             "description": "Sink connector type"
           },
           "source": {

--- a/transformations/src/main/resources/META-INF/services/com.dataweaver.core.plugin.TransformPlugin
+++ b/transformations/src/main/resources/META-INF/services/com.dataweaver.core.plugin.TransformPlugin
@@ -1,2 +1,6 @@
 com.dataweaver.transformations.sql.SQLTransformPlugin
 com.dataweaver.transformations.quality.DataQualityPlugin
+com.dataweaver.transformations.llm.LLMTransformPlugin
+com.dataweaver.transformations.rag.ChunkingPlugin
+com.dataweaver.transformations.rag.EmbeddingPlugin
+com.dataweaver.transformations.rag.GraphExtractionPlugin

--- a/transformations/src/main/scala/com/dataweaver/transformations/llm/LLMTransformPlugin.scala
+++ b/transformations/src/main/scala/com/dataweaver/transformations/llm/LLMTransformPlugin.scala
@@ -1,0 +1,243 @@
+package com.dataweaver.transformations.llm
+
+import com.dataweaver.core.plugin.{TransformConfig, TransformPlugin}
+import org.apache.log4j.LogManager
+import org.apache.spark.sql.{DataFrame, Row, SparkSession}
+import org.apache.spark.sql.types._
+
+import java.net.URI
+import java.net.http.{HttpClient, HttpRequest, HttpResponse}
+import java.security.MessageDigest
+import scala.collection.mutable
+import scala.util.{Failure, Success, Try}
+
+/** LLM-as-transformation plugin.
+  * Calls an LLM API for each batch of rows, parses structured JSON output,
+  * and returns a new DataFrame with the output schema.
+  *
+  * Config (via extra map):
+  *   provider       - claude | openai | vertex-ai (default: claude)
+  *   model          - model name
+  *   prompt         - prompt template with {column_name} placeholders
+  *   inputColumns   - comma-separated list of columns to inject into prompt
+  *   outputSchema   - pipe-separated field definitions: name:type|name:type
+  *   batchSize      - rows per LLM call (default: 1)
+  *   maxConcurrent  - parallel LLM calls (default: 5)
+  *   retryOnError   - retry count (default: 3)
+  *   cache          - true|false, content-hash cache (default: false)
+  *   apiKey         - API key (or use env var)
+  */
+class LLMTransformPlugin extends TransformPlugin {
+  private val logger = LogManager.getLogger(getClass)
+
+  def transformType: String = "LLMTransform"
+
+  def transform(inputs: Map[String, DataFrame], config: TransformConfig)(implicit
+      spark: SparkSession
+  ): DataFrame = {
+    val df = inputs.values.headOption.getOrElse(
+      throw new IllegalArgumentException(s"LLMTransform '${config.id}' requires at least one input"))
+
+    val provider = config.extra.getOrElse("provider", "claude")
+    val model = config.extra.getOrElse("model", "claude-sonnet-4-20250514")
+    val promptTemplate = config.extra.getOrElse("prompt",
+      throw new IllegalArgumentException(s"LLMTransform '${config.id}' requires 'prompt' in config"))
+    val inputColumns = config.extra.getOrElse("inputColumns", "").split(",").map(_.trim).filter(_.nonEmpty)
+    val outputSchemaStr = config.extra.getOrElse("outputSchema", "result:string")
+    val batchSize = config.extra.getOrElse("batchSize", "1").toInt
+    val maxConcurrent = config.extra.getOrElse("maxConcurrent", "5").toInt
+    val retryCount = config.extra.getOrElse("retryOnError", "3").toInt
+    val useCache = config.extra.getOrElse("cache", "false").toBoolean
+    val apiKey = resolveApiKey(config.extra, provider)
+
+    // Parse output schema
+    val outputFields = parseOutputSchema(outputSchemaStr)
+    val outputStructType = StructType(outputFields.map { case (name, tpe) =>
+      StructField(name, tpe, nullable = true)
+    })
+
+    // Collect input data for processing
+    val inputData = df.collect().toList
+    val inputSchema = df.schema
+
+    // Process in batches with LLM
+    val cache = if (useCache) Some(mutable.Map[String, String]()) else None
+    val results = inputData.grouped(batchSize).flatMap { batch =>
+      val prompt = buildPromptForBatch(promptTemplate, batch, inputColumns, inputSchema)
+      val cacheKey = if (useCache) Some(hashContent(prompt)) else None
+
+      val response = cacheKey.flatMap(k => cache.flatMap(_.get(k))) match {
+        case Some(cached) =>
+          logger.info(s"Cache hit for LLMTransform '${config.id}'")
+          cached
+        case None =>
+          val result = callLLMWithRetry(prompt, provider, model, apiKey, retryCount)
+          cacheKey.foreach(k => cache.foreach(_.update(k, result)))
+          result
+      }
+
+      parseJsonResponse(response, outputFields)
+    }.toList
+
+    // Create output DataFrame
+    val rows = results.map(values => Row.fromSeq(values))
+    val rdd = spark.sparkContext.parallelize(rows)
+    spark.createDataFrame(rdd, outputStructType)
+  }
+
+  private def buildPromptForBatch(
+      template: String, batch: List[Row], inputColumns: Array[String], schema: StructType
+  ): String = {
+    if (batch.size == 1) {
+      var prompt = template
+      val row = batch.head
+      inputColumns.foreach { col =>
+        val idx = schema.fieldIndex(col)
+        val value = Option(row.get(idx)).map(_.toString).getOrElse("")
+        prompt = prompt.replace(s"{$col}", value)
+      }
+      prompt
+    } else {
+      val items = batch.map { row =>
+        inputColumns.map { col =>
+          val idx = schema.fieldIndex(col)
+          s"$col: ${Option(row.get(idx)).map(_.toString).getOrElse("")}"
+        }.mkString(", ")
+      }.mkString("\n---\n")
+      s"$template\n\nProcess these ${batch.size} items:\n$items\n\nReturn a JSON array with one object per item."
+    }
+  }
+
+  private def callLLMWithRetry(
+      prompt: String, provider: String, model: String, apiKey: String, maxRetries: Int
+  ): String = {
+    var lastError: String = ""
+    for (attempt <- 1 to maxRetries) {
+      Try(callLLM(prompt, provider, model, apiKey)) match {
+        case Success(response) => return response
+        case Failure(e) =>
+          lastError = e.getMessage
+          logger.warn(s"LLM call attempt $attempt/$maxRetries failed: $lastError")
+          if (attempt < maxRetries) Thread.sleep(attempt * 1000L) // exponential backoff
+      }
+    }
+    throw new RuntimeException(s"LLM call failed after $maxRetries attempts: $lastError")
+  }
+
+  private def callLLM(prompt: String, provider: String, model: String, apiKey: String): String = {
+    val escapedPrompt = prompt.replace("\\", "\\\\").replace("\"", "\\\"").replace("\n", "\\n")
+    val (url, headers, body) = provider match {
+      case "claude" =>
+        (
+          "https://api.anthropic.com/v1/messages",
+          Map("x-api-key" -> apiKey, "anthropic-version" -> "2023-06-01", "Content-Type" -> "application/json"),
+          s"""{"model":"$model","max_tokens":4096,"messages":[{"role":"user","content":"$escapedPrompt"}]}"""
+        )
+      case "local" =>
+        // Ollama-compatible API (OpenAI-compatible endpoint)
+        (
+          "http://localhost:11434/v1/chat/completions",
+          Map("Content-Type" -> "application/json"),
+          s"""{"model":"$model","messages":[{"role":"user","content":"$escapedPrompt"}]}"""
+        )
+      case _ => // openai and any other OpenAI-compatible provider
+        val apiUrl = if (provider == "openai") "https://api.openai.com/v1/chat/completions"
+                     else s"https://api.$provider.com/v1/chat/completions" // extensible
+        (
+          apiUrl,
+          Map("Authorization" -> s"Bearer $apiKey", "Content-Type" -> "application/json"),
+          s"""{"model":"$model","max_tokens":4096,"messages":[{"role":"user","content":"$escapedPrompt"}]}"""
+        )
+    }
+
+    val client = HttpClient.newHttpClient()
+    val builder = HttpRequest.newBuilder().uri(URI.create(url))
+      .POST(HttpRequest.BodyPublishers.ofString(body))
+    headers.foreach { case (k, v) => builder.header(k, v) }
+
+    val response = client.send(builder.build(), HttpResponse.BodyHandlers.ofString())
+    if (response.statusCode() >= 400) {
+      throw new RuntimeException(s"LLM API error (${response.statusCode()}): ${response.body().take(500)}")
+    }
+
+    // Extract text from response
+    val textPattern = """"text"\s*:\s*"((?:[^"\\]|\\.)*)"""".r
+    val contentPattern = """"content"\s*:\s*"((?:[^"\\]|\\.)*)"""".r
+
+    val pattern = if (provider == "claude") textPattern else contentPattern
+    pattern.findFirstMatchIn(response.body()) match {
+      case Some(m) => m.group(1).replace("\\n", "\n").replace("\\\"", "\"")
+      case None    => throw new RuntimeException(s"Cannot parse LLM response")
+    }
+  }
+
+  private def parseOutputSchema(schemaStr: String): List[(String, DataType)] = {
+    schemaStr.split("\\|").map(_.trim).map { field =>
+      field.split(":") match {
+        case Array(name, tpe) => (name.trim, tpe.trim.toLowerCase match {
+          case "string"  => StringType
+          case "integer" | "int" => IntegerType
+          case "long"    => LongType
+          case "double"  => DoubleType
+          case "boolean" => BooleanType
+          case "float"   => FloatType
+          case _         => StringType
+        })
+        case Array(name) => (name.trim, StringType)
+        case _           => ("result", StringType)
+      }
+    }.toList
+  }
+
+  private def parseJsonResponse(response: String, schema: List[(String, DataType)]): List[List[Any]] = {
+    // Simple JSON extraction — parse each field from the response
+    val results = mutable.ListBuffer[List[Any]]()
+
+    // Try to extract as single object
+    val values = schema.map { case (name, dataType) =>
+      val pattern = s""""$name"\\s*:\\s*"?([^",}]*)"?""".r
+      pattern.findFirstMatchIn(response) match {
+        case Some(m) => castValue(m.group(1).trim, dataType)
+        case None    => null
+      }
+    }
+    results += values
+
+    results.toList
+  }
+
+  private def castValue(value: String, dataType: DataType): Any = {
+    if (value == null || value == "null" || value.isEmpty) return null
+    try {
+      dataType match {
+        case StringType  => value.stripPrefix("\"").stripSuffix("\"")
+        case IntegerType => value.toInt
+        case LongType    => value.toLong
+        case DoubleType  => value.toDouble
+        case FloatType   => value.toFloat
+        case BooleanType => value.toBoolean
+        case _           => value
+      }
+    } catch {
+      case _: Exception => null
+    }
+  }
+
+  private def resolveApiKey(config: Map[String, String], provider: String): String = {
+    config.getOrElse("apiKey", {
+      provider match {
+        case "claude" => sys.env.getOrElse("ANTHROPIC_API_KEY", "")
+        case "openai" => sys.env.getOrElse("OPENAI_API_KEY", "")
+        case "local"  => "" // Ollama doesn't need an API key
+        case _        => ""
+      }
+    })
+  }
+
+  private def hashContent(content: String): String = {
+    MessageDigest.getInstance("SHA-256")
+      .digest(content.getBytes("UTF-8"))
+      .map("%02x".format(_))
+      .mkString
+  }
+}

--- a/transformations/src/main/scala/com/dataweaver/transformations/rag/ChunkingPlugin.scala
+++ b/transformations/src/main/scala/com/dataweaver/transformations/rag/ChunkingPlugin.scala
@@ -1,0 +1,102 @@
+package com.dataweaver.transformations.rag
+
+import com.dataweaver.core.plugin.{TransformConfig, TransformPlugin}
+import org.apache.log4j.LogManager
+import org.apache.spark.sql.{DataFrame, SparkSession}
+import org.apache.spark.sql.functions._
+
+/** Splits text documents into chunks for RAG processing.
+  *
+  * Config (via extra map):
+  *   strategy    - fixed | sentence | recursive (default: fixed)
+  *   size        - chunk size in characters (default: 512)
+  *   overlap     - overlap between chunks in characters (default: 50)
+  *   textColumn  - column containing text to chunk (default: "text")
+  *   idColumn    - column for document ID (default: "id")
+  */
+class ChunkingPlugin extends TransformPlugin {
+  private val logger = LogManager.getLogger(getClass)
+
+  def transformType: String = "Chunking"
+
+  def transform(inputs: Map[String, DataFrame], config: TransformConfig)(implicit
+      spark: SparkSession
+  ): DataFrame = {
+    val df = inputs.values.headOption.getOrElse(
+      throw new IllegalArgumentException(s"Chunking '${config.id}' requires input"))
+
+    val strategy = config.extra.getOrElse("strategy", "fixed")
+    val chunkSize = config.extra.getOrElse("size", "512").toInt
+    val overlap = config.extra.getOrElse("overlap", "50").toInt
+    val textColumn = config.extra.getOrElse("textColumn", "text")
+    val idColumn = config.extra.getOrElse("idColumn", "id")
+
+    import spark.implicits._
+
+    // Collect and chunk locally (chunking is a CPU operation, not data-parallel)
+    val chunked = df.select(col(idColumn), col(textColumn)).collect().flatMap { row =>
+      val docId = row.get(0).toString
+      val text = Option(row.get(1)).map(_.toString).getOrElse("")
+
+      val chunks = strategy match {
+        case "sentence" => chunkBySentence(text, chunkSize, overlap)
+        case "recursive" => chunkRecursive(text, chunkSize, overlap)
+        case _ => chunkFixed(text, chunkSize, overlap) // "fixed"
+      }
+
+      chunks.zipWithIndex.map { case (chunk, idx) =>
+        (docId, s"${docId}_chunk_$idx", idx, chunk, chunk.length)
+      }
+    }
+
+    chunked.toSeq.toDF("doc_id", "chunk_id", "chunk_index", "text", "chunk_length")
+  }
+
+  /** Fixed-size chunking with overlap. */
+  private def chunkFixed(text: String, size: Int, overlap: Int): List[String] = {
+    if (text.isEmpty) return List.empty
+    val step = math.max(1, size - overlap)
+    (0 until text.length by step)
+      .map(i => text.substring(i, math.min(i + size, text.length)))
+      .filter(_.nonEmpty)
+      .toList
+  }
+
+  /** Sentence-based chunking — split on sentence boundaries, group up to size. */
+  private def chunkBySentence(text: String, size: Int, overlap: Int): List[String] = {
+    val sentences = text.split("(?<=[.!?])\\s+").toList
+    val chunks = scala.collection.mutable.ListBuffer[String]()
+    var current = new StringBuilder()
+
+    sentences.foreach { sentence =>
+      if (current.length + sentence.length > size && current.nonEmpty) {
+        chunks += current.toString.trim
+        // Keep overlap from end of current chunk
+        val overlapText = current.toString.takeRight(overlap)
+        current = new StringBuilder(overlapText)
+      }
+      current.append(sentence).append(" ")
+    }
+    if (current.nonEmpty) chunks += current.toString.trim
+
+    chunks.toList
+  }
+
+  /** Recursive chunking — try paragraph splits first, then sentences, then fixed. */
+  private def chunkRecursive(text: String, size: Int, overlap: Int): List[String] = {
+    if (text.length <= size) return List(text)
+
+    // Try splitting by paragraphs
+    val paragraphs = text.split("\n\n+").toList
+    if (paragraphs.size > 1) {
+      return paragraphs.flatMap(p => chunkRecursive(p, size, overlap))
+    }
+
+    // Fall back to sentence splitting
+    val sentenceChunks = chunkBySentence(text, size, overlap)
+    if (sentenceChunks.forall(_.length <= size * 1.2)) return sentenceChunks
+
+    // Last resort: fixed size
+    chunkFixed(text, size, overlap)
+  }
+}

--- a/transformations/src/main/scala/com/dataweaver/transformations/rag/EmbeddingPlugin.scala
+++ b/transformations/src/main/scala/com/dataweaver/transformations/rag/EmbeddingPlugin.scala
@@ -1,0 +1,118 @@
+package com.dataweaver.transformations.rag
+
+import com.dataweaver.core.plugin.{TransformConfig, TransformPlugin}
+import org.apache.log4j.LogManager
+import org.apache.spark.sql.{DataFrame, Row, SparkSession}
+import org.apache.spark.sql.types._
+
+import java.net.URI
+import java.net.http.{HttpClient, HttpRequest, HttpResponse}
+
+/** Generates vector embeddings by calling an embedding API.
+  * Returns the input DataFrame with an additional "embedding" column (array of doubles).
+  *
+  * Config (via extra map):
+  *   provider    - vertex-ai | openai | cohere (default: openai)
+  *   model       - embedding model name (default: text-embedding-3-small)
+  *   textColumn  - column containing text to embed (default: "text")
+  *   batchSize   - texts per API call (default: 10)
+  *   apiKey      - API key (or use env var)
+  */
+class EmbeddingPlugin extends TransformPlugin {
+  private val logger = LogManager.getLogger(getClass)
+  private val httpClient = HttpClient.newHttpClient()
+
+  def transformType: String = "Embedding"
+
+  def transform(inputs: Map[String, DataFrame], config: TransformConfig)(implicit
+      spark: SparkSession
+  ): DataFrame = {
+    val df = inputs.values.headOption.getOrElse(
+      throw new IllegalArgumentException(s"Embedding '${config.id}' requires input"))
+
+    val provider = config.extra.getOrElse("provider", "openai")
+    val model = config.extra.getOrElse("model", defaultModel(provider))
+    val textColumn = config.extra.getOrElse("textColumn", "text")
+    val batchSize = config.extra.getOrElse("batchSize", "10").toInt
+    val apiKey = config.extra.getOrElse("apiKey", resolveApiKey(provider))
+
+    // Collect texts
+    val rows = df.collect().toList
+    val textIdx = df.schema.fieldIndex(textColumn)
+
+    // Generate embeddings in batches
+    val allEmbeddings = rows.grouped(batchSize).flatMap { batch =>
+      val texts = batch.map(r => Option(r.get(textIdx)).map(_.toString).getOrElse(""))
+      callEmbeddingAPI(texts.toList, provider, model, apiKey)
+    }.toList
+
+    // Create output DataFrame with embedding column
+    val outputRows = rows.zip(allEmbeddings).map { case (row, embedding) =>
+      Row.fromSeq(row.toSeq :+ embedding)
+    }
+
+    val embeddingField = StructField("embedding", ArrayType(DoubleType), nullable = true)
+    val outputSchema = StructType(df.schema.fields :+ embeddingField)
+
+    spark.createDataFrame(spark.sparkContext.parallelize(outputRows), outputSchema)
+  }
+
+  private def callEmbeddingAPI(
+      texts: List[String], provider: String, model: String, apiKey: String
+  ): List[Seq[Double]] = {
+    provider match {
+      case "openai" => callOpenAIEmbedding(texts, model, apiKey)
+      case _        => callOpenAIEmbedding(texts, model, apiKey) // default to OpenAI-compatible
+    }
+  }
+
+  private def callOpenAIEmbedding(texts: List[String], model: String, apiKey: String): List[Seq[Double]] = {
+    val escapedTexts = texts.map(t =>
+      t.replace("\\", "\\\\").replace("\"", "\\\"").replace("\n", " ").take(8000))
+    val inputArray = escapedTexts.map(t => s""""$t"""").mkString(",")
+    val body = s"""{"model":"$model","input":[$inputArray]}"""
+
+    val request = HttpRequest.newBuilder()
+      .uri(URI.create("https://api.openai.com/v1/embeddings"))
+      .header("Content-Type", "application/json")
+      .header("Authorization", s"Bearer $apiKey")
+      .POST(HttpRequest.BodyPublishers.ofString(body))
+      .build()
+
+    val response = httpClient.send(request, HttpResponse.BodyHandlers.ofString())
+    if (response.statusCode() >= 400) {
+      throw new RuntimeException(s"Embedding API error (${response.statusCode()}): ${response.body().take(500)}")
+    }
+
+    // Parse embeddings from response
+    parseEmbeddings(response.body(), texts.size)
+  }
+
+  /** Simple embedding parser — extracts arrays of floats from JSON response. */
+  private def parseEmbeddings(json: String, expectedCount: Int): List[Seq[Double]] = {
+    val embeddingPattern = """\[(-?[\d.]+(?:,-?[\d.]+)*)\]""".r
+    val allMatches = embeddingPattern.findAllMatchIn(json).toList
+
+    // Skip the first match (it's the input array), take embedding arrays
+    val embeddings = allMatches.drop(1).take(expectedCount).map { m =>
+      m.group(1).split(",").map(_.trim.toDouble).toSeq
+    }
+
+    // Pad with empty embeddings if needed
+    embeddings.toList.padTo(expectedCount, Seq.empty[Double])
+  }
+
+  private def defaultModel(provider: String): String = provider match {
+    case "openai"    => "text-embedding-3-small"
+    case "vertex-ai" => "text-embedding-004"
+    case "cohere"    => "embed-english-v3.0"
+    case _           => "text-embedding-3-small"
+  }
+
+  private def resolveApiKey(provider: String): String = provider match {
+    case "openai"    => sys.env.getOrElse("OPENAI_API_KEY", "")
+    case "vertex-ai" => sys.env.getOrElse("GOOGLE_API_KEY", "")
+    case "cohere"    => sys.env.getOrElse("COHERE_API_KEY", "")
+    case _           => ""
+  }
+}

--- a/transformations/src/main/scala/com/dataweaver/transformations/rag/GraphExtractionPlugin.scala
+++ b/transformations/src/main/scala/com/dataweaver/transformations/rag/GraphExtractionPlugin.scala
@@ -1,0 +1,150 @@
+package com.dataweaver.transformations.rag
+
+import com.dataweaver.core.plugin.{TransformConfig, TransformPlugin}
+import org.apache.log4j.LogManager
+import org.apache.spark.sql.{DataFrame, Row, SparkSession}
+import org.apache.spark.sql.types._
+
+import java.net.URI
+import java.net.http.{HttpClient, HttpRequest, HttpResponse}
+
+/** Extracts entities and relationships from text using an LLM.
+  * Returns a DataFrame with columns: source_entity, source_type, relation, target_entity, target_type
+  *
+  * Config (via extra map):
+  *   provider    - claude | openai | local (default: claude)
+  *   model       - model name
+  *   textColumn  - column with text to analyze (default: "text")
+  *   entityTypes - comma-separated entity types to extract (default: "Person,Organization,Product")
+  *   apiKey      - API key (or env var, not needed for local)
+  *   baseUrl     - custom API URL (for local/Ollama: http://localhost:11434/v1)
+  */
+class GraphExtractionPlugin extends TransformPlugin {
+  private val logger = LogManager.getLogger(getClass)
+  private val httpClient = HttpClient.newHttpClient()
+
+  def transformType: String = "GraphExtraction"
+
+  def transform(inputs: Map[String, DataFrame], config: TransformConfig)(implicit
+      spark: SparkSession
+  ): DataFrame = {
+    val df = inputs.values.headOption.getOrElse(
+      throw new IllegalArgumentException(s"GraphExtraction '${config.id}' requires input"))
+
+    val provider = config.extra.getOrElse("provider", "claude")
+    val model = config.extra.getOrElse("model", defaultModel(provider))
+    val textColumn = config.extra.getOrElse("textColumn", "text")
+    val entityTypes = config.extra.getOrElse("entityTypes", "Person,Organization,Product")
+    val apiKey = config.extra.getOrElse("apiKey", resolveApiKey(provider))
+    val baseUrl = config.extra.get("baseUrl")
+
+    val textIdx = df.schema.fieldIndex(textColumn)
+    val rows = df.collect().toList
+
+    val allRelations = rows.flatMap { row =>
+      val text = Option(row.get(textIdx)).map(_.toString).getOrElse("")
+      if (text.isEmpty) List.empty
+      else extractEntities(text, entityTypes, provider, model, apiKey, baseUrl)
+    }
+
+    // Create output DataFrame
+    val schema = StructType(Seq(
+      StructField("source_entity", StringType),
+      StructField("source_type", StringType),
+      StructField("relation", StringType),
+      StructField("target_entity", StringType),
+      StructField("target_type", StringType)
+    ))
+
+    val outputRows = allRelations.map { case (se, st, rel, te, tt) =>
+      Row(se, st, rel, te, tt)
+    }
+
+    spark.createDataFrame(spark.sparkContext.parallelize(outputRows), schema)
+  }
+
+  private def extractEntities(
+      text: String, entityTypes: String,
+      provider: String, model: String, apiKey: String, baseUrl: Option[String]
+  ): List[(String, String, String, String, String)] = {
+    val prompt = s"""Extract entities and relationships from this text.
+Entity types to look for: $entityTypes
+
+Text: ${text.take(4000)}
+
+Return ONLY a JSON array of objects with these fields:
+- source_entity: the subject entity name
+- source_type: entity type of the subject
+- relation: the relationship (e.g., "works_at", "created", "part_of")
+- target_entity: the object entity name
+- target_type: entity type of the object
+
+Example: [{"source_entity":"Alice","source_type":"Person","relation":"works_at","target_entity":"Acme","target_type":"Organization"}]
+
+JSON array:"""
+
+    val response = callLLM(prompt, provider, model, apiKey, baseUrl)
+    parseRelations(response)
+  }
+
+  private def callLLM(
+      prompt: String, provider: String, model: String, apiKey: String, baseUrl: Option[String]
+  ): String = {
+    val escapedPrompt = prompt.replace("\\", "\\\\").replace("\"", "\\\"").replace("\n", "\\n")
+
+    val (url, headers, body) = provider match {
+      case "local" =>
+        val localUrl = baseUrl.getOrElse("http://localhost:11434/v1/chat/completions")
+        (localUrl,
+          Map("Content-Type" -> "application/json"),
+          s"""{"model":"$model","messages":[{"role":"user","content":"$escapedPrompt"}]}""")
+      case "claude" =>
+        ("https://api.anthropic.com/v1/messages",
+          Map("x-api-key" -> apiKey, "anthropic-version" -> "2023-06-01", "Content-Type" -> "application/json"),
+          s"""{"model":"$model","max_tokens":4096,"messages":[{"role":"user","content":"$escapedPrompt"}]}""")
+      case _ => // openai-compatible
+        val apiUrl = baseUrl.getOrElse("https://api.openai.com/v1/chat/completions")
+        (apiUrl,
+          Map("Authorization" -> s"Bearer $apiKey", "Content-Type" -> "application/json"),
+          s"""{"model":"$model","max_tokens":4096,"messages":[{"role":"user","content":"$escapedPrompt"}]}""")
+    }
+
+    val builder = HttpRequest.newBuilder().uri(URI.create(url))
+      .POST(HttpRequest.BodyPublishers.ofString(body))
+    headers.foreach { case (k, v) => builder.header(k, v) }
+
+    val response = httpClient.send(builder.build(), HttpResponse.BodyHandlers.ofString())
+    if (response.statusCode() >= 400) {
+      logger.error(s"LLM API error: ${response.body().take(300)}")
+      return "[]"
+    }
+
+    val textPattern = """"(?:text|content)"\s*:\s*"((?:[^"\\]|\\.)*)"""".r
+    textPattern.findFirstMatchIn(response.body())
+      .map(_.group(1).replace("\\n", "\n").replace("\\\"", "\""))
+      .getOrElse("[]")
+  }
+
+  private def parseRelations(json: String): List[(String, String, String, String, String)] = {
+    // Simple regex-based JSON array parser
+    val objectPattern = """\{[^}]*"source_entity"\s*:\s*"([^"]*)"[^}]*"source_type"\s*:\s*"([^"]*)"[^}]*"relation"\s*:\s*"([^"]*)"[^}]*"target_entity"\s*:\s*"([^"]*)"[^}]*"target_type"\s*:\s*"([^"]*)"""".r
+
+    objectPattern.findAllMatchIn(json).map { m =>
+      (m.group(1), m.group(2), m.group(3), m.group(4), m.group(5))
+    }.toList
+  }
+
+  private def defaultModel(provider: String): String = provider match {
+    case "claude" => "claude-sonnet-4-20250514"
+    case "openai" => "gpt-4o-mini"
+    case "local"  => "llama3"
+    case _        => "gpt-4o-mini"
+  }
+
+  private def resolveApiKey(provider: String): String = provider match {
+    case "claude" => sys.env.getOrElse("ANTHROPIC_API_KEY", "")
+    case "openai" => sys.env.getOrElse("OPENAI_API_KEY", "")
+    case "local"  => "" // no key needed
+    case _        => ""
+  }
+}


### PR DESCRIPTION
## Summary

Adds LLM-as-transformation capabilities and RAG data preparation transforms.

### LLM Transforms
- **LLMTransformPlugin**: generic transform that calls any LLM API with prompt templating, structured JSON output, batching, content-hash caching, and retry with exponential backoff
- Supports **claude**, **openai**, **local** (Ollama), and any OpenAI-compatible API via custom `baseUrl`

### RAG Transforms
- **ChunkingPlugin**: split documents into chunks (fixed, sentence, recursive strategies)
- **EmbeddingPlugin**: generate vector embeddings via OpenAI/Vertex AI/Cohere APIs
- **GraphExtractionPlugin**: extract entities and relationships using LLM

### Local Model Support
All LLM plugins support `provider: local` for Ollama (http://localhost:11434). No API key required. Custom `baseUrl` supported for self-hosted endpoints.

### Example YAML
```yaml
transformations:
  - id: classify
    type: LLMTransform
    sources: [data]
    config:
      provider: local
      model: llama3
      prompt: "Classify: {text}"
      outputSchema: "category:string|confidence:double"
      batchSize: 5
      cache: true
```

## Test plan

- [x] `sbt compile` — All modules compile
- [ ] CI green
- [ ] Manual: LLMTransform with Ollama local model