### PR TITLE
feat: Tutorial 6 — Web scraping with LLM for supermarket pricing

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ Ready-to-run example pipelines in [`docs/tutorials/`](docs/tutorials/):
 | [03 — RAG Pipeline](docs/tutorials/03-rag-pipeline.yaml) | Chunk documents for vector search | Chunking, RAG preparation |
 | [04 — LLM Classification](docs/tutorials/04-llm-classification.yaml) | Classify tickets with Gemini/Ollama | LLMTransform, local models |
 | [05 — Production ETL](docs/tutorials/05-production-etl.yaml) | Full pipeline: PostgreSQL → DeltaLake | Connections, profiles, merge |
+| [06 — Web Scraping + LLM](docs/tutorials/06-web-scraping-llm.yaml) | Extract supermarket products from HTML with LLM | REST, LLMTransform, SQL |
 
 ```bash
 # Run a tutorial

--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ tests:
 | `Kafka` | Batch + streaming modes |
 | `MongoDB` | Collection reads with aggregation pipeline |
 | `REST` | Generic API with pagination and auth (bearer, API key) |
+| `Web` | Fetch HTML from URLs for web scraping (with delay, User-Agent) |
 | `BigQuery` | Table reads and SQL queries |
 | `Test` | JSON file reader for testing |
 

--- a/connectors/src/main/resources/META-INF/services/com.dataweaver.core.plugin.SourceConnector
+++ b/connectors/src/main/resources/META-INF/services/com.dataweaver.core.plugin.SourceConnector
@@ -6,3 +6,4 @@ com.dataweaver.connectors.sources.KafkaSourceConnector
 com.dataweaver.connectors.sources.MongoDBSourceConnector
 com.dataweaver.connectors.sources.RESTSourceConnector
 com.dataweaver.connectors.sources.BigQuerySourceConnector
+com.dataweaver.connectors.sources.WebSourceConnector

--- a/connectors/src/main/scala/com/dataweaver/connectors/sources/WebSourceConnector.scala
+++ b/connectors/src/main/scala/com/dataweaver/connectors/sources/WebSourceConnector.scala
@@ -1,0 +1,101 @@
+package com.dataweaver.connectors.sources
+
+import com.dataweaver.core.plugin.SourceConnector
+import org.apache.log4j.LogManager
+import org.apache.spark.sql.{DataFrame, SparkSession}
+
+import java.net.URI
+import java.net.http.{HttpClient, HttpRequest, HttpResponse}
+import scala.collection.mutable.ListBuffer
+
+/** Fetches web pages and returns their HTML content as a DataFrame.
+  * Designed for web scraping pipelines where the HTML is then parsed by LLMTransform.
+  *
+  * Config:
+  *   urls       - Comma-separated list of URLs to fetch
+  *   urlFile    - Path to a file with one URL per line (alternative to urls)
+  *   userAgent  - Custom User-Agent header (default: "DataWeaver/0.2")
+  *   delay      - Delay between requests in ms (default: 1000, be respectful)
+  *   timeout    - Request timeout in seconds (default: 30)
+  *
+  * Returns DataFrame with columns: url, html, status_code, fetched_at
+  */
+class WebSourceConnector extends SourceConnector {
+  private val logger = LogManager.getLogger(getClass)
+  private val httpClient = HttpClient.newBuilder()
+    .followRedirects(HttpClient.Redirect.NORMAL)
+    .build()
+
+  def connectorType: String = "Web"
+
+  def read(config: Map[String, String])(implicit spark: SparkSession): DataFrame = {
+    val urls = resolveUrls(config)
+    val userAgent = config.getOrElse("userAgent", "DataWeaver/0.2")
+    val delay = config.getOrElse("delay", "1000").toLong
+    val timeout = config.getOrElse("timeout", "30").toInt
+
+    if (urls.isEmpty) {
+      throw new IllegalArgumentException("Web source: provide 'urls' (comma-separated) or 'urlFile' (path to file)")
+    }
+
+    logger.info(s"Fetching ${urls.size} web page(s)...")
+
+    val results = ListBuffer[(String, String, Int, String)]()
+
+    urls.foreach { url =>
+      try {
+        val request = HttpRequest.newBuilder()
+          .uri(URI.create(url))
+          .header("User-Agent", userAgent)
+          .header("Accept", "text/html,application/xhtml+xml,*/*")
+          .timeout(java.time.Duration.ofSeconds(timeout))
+          .GET()
+          .build()
+
+        val response = httpClient.send(request, HttpResponse.BodyHandlers.ofString())
+        results += ((url, response.body(), response.statusCode(), java.time.Instant.now().toString))
+        logger.info(s"  Fetched: $url (${response.statusCode()}, ${response.body().length} chars)")
+
+        if (delay > 0 && urls.size > 1) Thread.sleep(delay)
+      } catch {
+        case e: Exception =>
+          logger.warn(s"  Failed: $url — ${e.getMessage}")
+          results += ((url, s"ERROR: ${e.getMessage}", 0, java.time.Instant.now().toString))
+      }
+    }
+
+    import spark.implicits._
+    results.toList.toDF("url", "html", "status_code", "fetched_at")
+  }
+
+  override def healthCheck(config: Map[String, String]): Either[String, Long] = {
+    val urls = resolveUrls(config)
+    if (urls.isEmpty) return Left("No URLs configured")
+    val url = urls.head
+    try {
+      val start = System.currentTimeMillis()
+      val request = HttpRequest.newBuilder()
+        .uri(URI.create(url))
+        .method("HEAD", HttpRequest.BodyPublishers.noBody())
+        .timeout(java.time.Duration.ofSeconds(5))
+        .build()
+      httpClient.send(request, HttpResponse.BodyHandlers.discarding())
+      Right(System.currentTimeMillis() - start)
+    } catch {
+      case e: Exception => Left(s"Cannot reach $url: ${e.getMessage}")
+    }
+  }
+
+  private def resolveUrls(config: Map[String, String]): List[String] = {
+    config.get("urls").map(_.split(",").map(_.trim).filter(_.nonEmpty).toList)
+      .orElse {
+        config.get("urlFile").map { path =>
+          scala.io.Source.fromFile(path).getLines()
+            .map(_.trim)
+            .filter(l => l.nonEmpty && !l.startsWith("#"))
+            .toList
+        }
+      }
+      .getOrElse(List.empty)
+  }
+}

--- a/core/src/main/resources/schemas/pipeline.schema.json
+++ b/core/src/main/resources/schemas/pipeline.schema.json
@@ -33,7 +33,7 @@
           },
           "type": {
             "type": "string",
-            "enum": ["PostgreSQL", "MySQL", "File", "Kafka", "MongoDB", "REST", "BigQuery", "Test"],
+            "enum": ["PostgreSQL", "MySQL", "File", "Kafka", "MongoDB", "REST", "Web", "BigQuery", "Test"],
             "description": "Source connector type"
           },
           "connection": {

--- a/docs/tutorials/06-web-scraping-llm.yaml
+++ b/docs/tutorials/06-web-scraping-llm.yaml
@@ -3,12 +3,12 @@
 # Real-world use case: Extract product data from a supermarket website
 # using an LLM to parse the HTML instead of brittle CSS selectors.
 #
-# The LLM reads raw HTML and extracts structured product information
-# (name, brand, price, unit price, category, weight). This approach
-# works across different websites without custom parsers.
+# The Web source fetches HTML directly from URLs.
+# The LLM reads raw HTML and extracts structured product information.
+# This approach works across different websites without custom parsers.
 #
 # Flow:
-#   Web pages (HTML) → LLM extracts products → SQL normalizes → Quality check → CSV report
+#   Web pages (live HTTP) → LLM extracts products → SQL normalizes → Quality check → CSV
 #
 # Requirements:
 #   - GEMINI_API_KEY, ANTHROPIC_API_KEY, or OPENAI_API_KEY
@@ -17,25 +17,30 @@
 # Run:
 #   weaver plan docs/tutorials/06-web-scraping-llm.yaml
 #   weaver apply docs/tutorials/06-web-scraping-llm.yaml
+#   weaver apply docs/tutorials/06-web-scraping-llm.yaml --env local  # Ollama
 
 name: SupermarketScraper
 tag: pricing
 engine: local
 
 dataSources:
-  # Step 1: Fetch HTML pages from the supermarket website
-  # In production, this would be a list of category/product page URLs
-  # Here we use sample HTML files to demonstrate the concept
+  # The Web source fetches HTML from URLs directly — no intermediate files
+  # In production: point to real supermarket category pages
+  # delay: ms between requests (be respectful with target servers)
   - id: web_pages
-    type: File
+    type: Web
     config:
-      path: docs/tutorials/data/sample_supermarket_pages.json
-      format: json
+      urls: >
+        https://example-supermarket.com/dairy,
+        https://example-supermarket.com/beverages,
+        https://example-supermarket.com/snacks
+      userAgent: DataWeaver/0.2
+      delay: "1500"
+      timeout: "30"
 
 transformations:
-  # Step 2: LLM reads the raw HTML and extracts structured product data
-  # This is the key differentiator — no CSS selectors, no XPath, no regex
-  # The LLM understands the page structure regardless of the website
+  # LLM reads the raw HTML and extracts structured product data
+  # No CSS selectors, no XPath, no regex — the LLM understands the page
   - id: extracted
     type: LLMTransform
     sources:
@@ -44,8 +49,8 @@ transformations:
       provider: gemini
       model: gemini-2.0-flash
       prompt: |
-        You are a product data extractor. Analyze this supermarket web page HTML
-        and extract ALL products found on the page.
+        You are a product data extractor. Analyze this supermarket web page
+        and extract ALL products visible on the page.
 
         Page URL: {url}
         HTML content: {html}
@@ -54,20 +59,19 @@ transformations:
         - product_name: full product name
         - brand: brand name (or "unknown")
         - price: price in euros (number only, e.g. 2.49)
-        - unit_price: price per kg/liter if available (number only, or "N/A")
-        - category: product category (e.g. "dairy", "beverages", "snacks")
+        - unit_price: price per kg/liter if available (or "N/A")
+        - category: product category (dairy, beverages, snacks, etc.)
         - weight: weight or volume (e.g. "500g", "1L", or "N/A")
 
-        Return ONLY a JSON object with these fields for the FIRST product found.
-        No explanation, no markdown.
+        Return a JSON object with these fields for the first product found.
       inputColumns: url,html
       outputSchema: product_name:string|brand:string|price:string|unit_price:string|category:string|weight:string
       batchSize: "1"
-      maxConcurrent: "3"
+      maxConcurrent: "2"
       retryOnError: "3"
       cache: "true"
 
-  # Step 3: Clean and normalize the extracted data with SQL
+  # Clean and normalize with SQL
   - id: normalized
     type: SQL
     sources:
@@ -84,9 +88,8 @@ transformations:
       FROM extracted
       WHERE product_name IS NOT NULL
         AND price IS NOT NULL
-        AND LENGTH(TRIM(product_name)) > 0
 
-  # Step 4: Quality gate — ensure we got real data
+  # Quality gate
   - id: validated
     type: DataQuality
     sources:
@@ -96,7 +99,7 @@ transformations:
     onFail: warn
 
 sinks:
-  # CSV report for the pricing team (opens in Excel)
+  # CSV for the pricing team (opens in Excel/Sheets)
   - id: pricing_report
     type: File
     source: validated
@@ -106,7 +109,7 @@ sinks:
       saveMode: Overwrite
       coalesce: "1"
 
-  # JSON for the dashboard API
+  # JSON for dashboards or APIs
   - id: dashboard_data
     type: File
     source: validated
@@ -117,7 +120,7 @@ sinks:
       coalesce: "1"
 
 profiles:
-  # Use local Ollama model (free, no API key)
+  # Use local Ollama model (free, no API key needed)
   local:
     transformations.extracted.config.provider: local
     transformations.extracted.config.model: llama3

--- a/docs/tutorials/06-web-scraping-llm.yaml
+++ b/docs/tutorials/06-web-scraping-llm.yaml
@@ -1,0 +1,127 @@
+# Tutorial 6: Web scraping with LLM — Supermarket price extraction
+#
+# Real-world use case: Extract product data from a supermarket website
+# using an LLM to parse the HTML instead of brittle CSS selectors.
+#
+# The LLM reads raw HTML and extracts structured product information
+# (name, brand, price, unit price, category, weight). This approach
+# works across different websites without custom parsers.
+#
+# Flow:
+#   Web pages (HTML) → LLM extracts products → SQL normalizes → Quality check → CSV report
+#
+# Requirements:
+#   - GEMINI_API_KEY, ANTHROPIC_API_KEY, or OPENAI_API_KEY
+#   - Or use provider: local with Ollama (no API key)
+#
+# Run:
+#   weaver plan docs/tutorials/06-web-scraping-llm.yaml
+#   weaver apply docs/tutorials/06-web-scraping-llm.yaml
+
+name: SupermarketScraper
+tag: pricing
+engine: local
+
+dataSources:
+  # Step 1: Fetch HTML pages from the supermarket website
+  # In production, this would be a list of category/product page URLs
+  # Here we use sample HTML files to demonstrate the concept
+  - id: web_pages
+    type: File
+    config:
+      path: docs/tutorials/data/sample_supermarket_pages.json
+      format: json
+
+transformations:
+  # Step 2: LLM reads the raw HTML and extracts structured product data
+  # This is the key differentiator — no CSS selectors, no XPath, no regex
+  # The LLM understands the page structure regardless of the website
+  - id: extracted
+    type: LLMTransform
+    sources:
+      - web_pages
+    config:
+      provider: gemini
+      model: gemini-2.0-flash
+      prompt: |
+        You are a product data extractor. Analyze this supermarket web page HTML
+        and extract ALL products found on the page.
+
+        Page URL: {url}
+        HTML content: {html}
+
+        For each product, extract:
+        - product_name: full product name
+        - brand: brand name (or "unknown")
+        - price: price in euros (number only, e.g. 2.49)
+        - unit_price: price per kg/liter if available (number only, or "N/A")
+        - category: product category (e.g. "dairy", "beverages", "snacks")
+        - weight: weight or volume (e.g. "500g", "1L", or "N/A")
+
+        Return ONLY a JSON object with these fields for the FIRST product found.
+        No explanation, no markdown.
+      inputColumns: url,html
+      outputSchema: product_name:string|brand:string|price:string|unit_price:string|category:string|weight:string
+      batchSize: "1"
+      maxConcurrent: "3"
+      retryOnError: "3"
+      cache: "true"
+
+  # Step 3: Clean and normalize the extracted data with SQL
+  - id: normalized
+    type: SQL
+    sources:
+      - extracted
+    query: >
+      SELECT
+        product_name,
+        brand,
+        CAST(REGEXP_REPLACE(price, '[^0-9.]', '') AS DOUBLE) as price_eur,
+        unit_price,
+        LOWER(TRIM(category)) as category,
+        weight,
+        CURRENT_TIMESTAMP() as scraped_at
+      FROM extracted
+      WHERE product_name IS NOT NULL
+        AND price IS NOT NULL
+        AND LENGTH(TRIM(product_name)) > 0
+
+  # Step 4: Quality gate — ensure we got real data
+  - id: validated
+    type: DataQuality
+    sources:
+      - normalized
+    checks:
+      - row_count > 0
+    onFail: warn
+
+sinks:
+  # CSV report for the pricing team (opens in Excel)
+  - id: pricing_report
+    type: File
+    source: validated
+    config:
+      path: output/supermarket_prices
+      format: csv
+      saveMode: Overwrite
+      coalesce: "1"
+
+  # JSON for the dashboard API
+  - id: dashboard_data
+    type: File
+    source: validated
+    config:
+      path: output/supermarket_prices_json
+      format: json
+      saveMode: Overwrite
+      coalesce: "1"
+
+profiles:
+  # Use local Ollama model (free, no API key)
+  local:
+    transformations.extracted.config.provider: local
+    transformations.extracted.config.model: llama3
+
+tests:
+  - name: "products extracted"
+    assert: pricing_report.row_count > 0

--- a/docs/tutorials/data/sample_supermarket_pages.json
+++ b/docs/tutorials/data/sample_supermarket_pages.json
@@ -1,0 +1,14 @@
+[
+  {
+    "url": "https://example-supermarket.com/dairy",
+    "html": "<div class='product-card'><h3 class='product-title'>Leche Entera Hacendado</h3><span class='brand'>Hacendado</span><div class='price'>0.89 &euro;</div><span class='unit-price'>0.89 &euro;/L</span><span class='weight'>1L</span><span class='category-tag'>Lacteos</span></div><div class='product-card'><h3 class='product-title'>Yogur Natural Danone Pack 4</h3><span class='brand'>Danone</span><div class='price'>1.65 &euro;</div><span class='unit-price'>3.30 &euro;/kg</span><span class='weight'>4x125g</span><span class='category-tag'>Lacteos</span></div>"
+  },
+  {
+    "url": "https://example-supermarket.com/beverages",
+    "html": "<article data-product-id='8842'><div class='item-name'>Coca-Cola Original 2L</div><p class='manufacturer'>Coca-Cola</p><strong class='current-price'>1.95&euro;</strong><em class='price-per-unit'>0.98&euro;/L</em><span class='size'>2L</span></article><article data-product-id='8843'><div class='item-name'>Agua Mineral Bezoya Pack 6</div><p class='manufacturer'>Bezoya</p><strong class='current-price'>2.40&euro;</strong><em class='price-per-unit'>0.27&euro;/L</em><span class='size'>6x1.5L</span></article>"
+  },
+  {
+    "url": "https://example-supermarket.com/snacks",
+    "html": "<li class='shelf-item'><img src='chips.jpg'/><div class='details'><span class='name'>Patatas Fritas Lay's Clasicas</span><span class='maker'>Lay's</span><b class='tag-price'>1.79 EUR</b><small>11.93 EUR/kg</small><span>150g</span></div></li><li class='shelf-item'><img src='nuts.jpg'/><div class='details'><span class='name'>Almendras Tostadas Borges</span><span class='maker'>Borges</span><b class='tag-price'>3.25 EUR</b><small>13.00 EUR/kg</small><span>250g</span></div></li>"
+  }
+]


### PR DESCRIPTION
Real-world tutorial: extract product data from supermarket web pages using an LLM as universal HTML parser.

Pipeline: HTML pages → LLM extracts products → SQL normalizes → quality check → CSV + JSON

Demonstrates LLMTransform as HTML parser, SQL normalization, dual output, local model support.